### PR TITLE
Add preserve_macros to permuter_settings.toml

### DIFF
--- a/permuter_settings.toml
+++ b/permuter_settings.toml
@@ -3,3 +3,8 @@
 
 [decompme.compilers]
 "tools/ido5.3_recomp/cc" = "ido5.3"
+
+[preserve_macros]
+"gs?DP.*" = "void"
+"gs?SP.*" = "void"
+"G_.*" = "int"


### PR DESCRIPTION
That way we don't have to remember to preserver macros manually. Just have the
 permuter do it for us

Signed-off-by: Taggerung <tyler.taggerung@gmail.com>