### PR TITLE
Fix matching under Arch again

### DIFF
--- a/mk64.ld
+++ b/mk64.ld
@@ -357,6 +357,7 @@ SECTIONS
       BUILD_DIR/src/framebuffers.o(.bss*);
       BUILD_DIR/src/audio/synthesis.o(.bss*);
       BUILD_DIR/asm/bss_audio.o(.bss*);
+      . = ALIGN(0x8);
       BUILD_DIR/asm/bss_sptask_audio.o(.bss);
    }
    END_NOLOAD(code_8028DF00)


### PR DESCRIPTION
Commit 5ca8e07a4d5946192eee5c2c129ae00cc54b95b5 fixed the issue, then e9415164bb5786f0f5052f92d59843d6549b79e4 reverted the fix, so let's fix it again

After this commit the built file matches the original ROM again.