### PR TITLE
Add clean targets for each asset makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -379,8 +379,7 @@ distclean: distclean_assets
 	./extract_assets.py --clean
 	make -C tools clean
 
-distclean_assets:
-	rm -rf $(ASSET_DIRECTORIES)
+distclean_assets: ;
 
 test: $(ROM)
 	$(EMULATOR) $(EMU_FLAGS) $<

--- a/assets/include/blueshell.mk
+++ b/assets/include/blueshell.mk
@@ -14,8 +14,6 @@ $(BLUE_SHELL_DIR)/gTextureBlueShell8.png
 
 BLUE_SHELL_EXPORT_SENTINEL := $(BLUE_SHELL_DIR)/.export
 
-ASSET_DIRECTORIES += $(BLUE_SHELL_DIR)
-
 $(BLUE_SHELL_FRAMES:%.png=%.inc.c): %.inc.c : %.png
 	$(N64GRAPHICS) -Z $@ -g $< -s u8 -f ci8 -c rgba16 -p $(BLUE_SHELL_PALETTE)
 
@@ -29,3 +27,9 @@ $(BLUE_SHELL_FRAMES) $(BLUE_SHELL_PALETTE): $(BLUE_SHELL_EXPORT_SENTINEL) ;
 $(BLUE_SHELL_EXPORT_SENTINEL): $(ASSET_DIR)/blueshell.json
 	$(ASSET_EXTRACT) $(BASEROM) $<
 	touch $@
+
+.PHONY: distclean_blueshell
+distclean_blueshell:
+	rm -rf $(BLUE_SHELL_DIR)
+
+distclean_assets: distclean_blueshell

--- a/assets/include/character_select/bowser_select.mk
+++ b/assets/include/character_select/bowser_select.mk
@@ -21,8 +21,6 @@ $(BOWSER_SELECT_DIR)/bowser_face_16.png
 
 BOWSER_SELECT_EXPORT_SENTINEL := $(BOWSER_SELECT_DIR)/.export
 
-ASSET_DIRECTORIES += $(BOWSER_SELECT_DIR)
-
 $(BUILD_DIR)/data/course_player_selection.o: $(BOWSER_SELECT_PNG:%.png=%.mio0)
 
 $(BOWSER_SELECT_PNG:%.png=%.mio0) : %.mio0 : %.bin
@@ -36,3 +34,9 @@ $(BOWSER_SELECT_PNG): $(BOWSER_SELECT_EXPORT_SENTINEL) ;
 $(BOWSER_SELECT_EXPORT_SENTINEL): $(ASSET_DIR)/character_select/bowser_select.json
 	$(ASSET_EXTRACT) $(BASEROM) $<
 	touch $@
+
+.PHONY: distclean_bowser_select
+distclean_bowser_select:
+	rm -rf $(BOWSER_SELECT_DIR)
+
+distclean_assets: distclean_bowser_select

--- a/assets/include/character_select/donkeykong_select.mk
+++ b/assets/include/character_select/donkeykong_select.mk
@@ -21,8 +21,6 @@ $(DONKEYKONG_SELECT_DIR)/donkeykong_face_16.png
 
 DONKEYKONG_SELECT_EXPORT_SENTINEL := $(DONKEYKONG_SELECT_DIR)/.export
 
-ASSET_DIRECTORIES += $(DONKEYKONG_SELECT_DIR)
-
 $(BUILD_DIR)/data/course_player_selection.o: $(DONKEYKONG_SELECT_PNG:%.png=%.mio0)
 
 $(DONKEYKONG_SELECT_PNG:%.png=%.mio0) : %.mio0 : %.bin
@@ -36,3 +34,9 @@ $(DONKEYKONG_SELECT_PNG): $(DONKEYKONG_SELECT_EXPORT_SENTINEL) ;
 $(DONKEYKONG_SELECT_EXPORT_SENTINEL): $(ASSET_DIR)/character_select/donkeykong_select.json
 	$(ASSET_EXTRACT) $(BASEROM) $<
 	touch $@
+
+.PHONY: distclean_donkeykong_select
+distclean_donkeykong_select:
+	rm -rf $(DONKEYKONG_SELECT_DIR)
+
+distclean_assets: distclean_donkeykong_select

--- a/assets/include/character_select/luigi_select.mk
+++ b/assets/include/character_select/luigi_select.mk
@@ -21,8 +21,6 @@ $(LUIGI_SELECT_DIR)/luigi_face_16.png
 
 LUIGI_SELECT_EXPORT_SENTINEL := $(LUIGI_SELECT_DIR)/.export
 
-ASSET_DIRECTORIES += $(LUIGI_SELECT_DIR)
-
 $(BUILD_DIR)/data/course_player_selection.o: $(LUIGI_SELECT_PNG:%.png=%.mio0)
 
 $(LUIGI_SELECT_PNG:%.png=%.mio0) : %.mio0 : %.bin
@@ -36,3 +34,9 @@ $(LUIGI_SELECT_PNG): $(LUIGI_SELECT_EXPORT_SENTINEL) ;
 $(LUIGI_SELECT_EXPORT_SENTINEL): $(ASSET_DIR)/character_select/luigi_select.json
 	$(ASSET_EXTRACT) $(BASEROM) $<
 	touch $@
+
+.PHONY: distclean_luigi_select
+distclean_luigi_select:
+	rm -rf $(LUIGI_SELECT_DIR)
+
+distclean_assets: distclean_luigi_select

--- a/assets/include/character_select/mario_select.mk
+++ b/assets/include/character_select/mario_select.mk
@@ -21,8 +21,6 @@ $(MARIO_SELECT_DIR)/mario_face_16.png
 
 MARIO_SELECT_EXPORT_SENTINEL := $(MARIO_SELECT_DIR)/.export
 
-ASSET_DIRECTORIES += $(MARIO_SELECT_DIR)
-
 $(BUILD_DIR)/data/course_player_selection.o: $(MARIO_SELECT_PNG:%.png=%.mio0)
 
 $(MARIO_SELECT_PNG:%.png=%.mio0) : %.mio0 : %.bin
@@ -36,3 +34,9 @@ $(MARIO_SELECT_PNG): $(MARIO_SELECT_EXPORT_SENTINEL) ;
 $(MARIO_SELECT_EXPORT_SENTINEL): $(ASSET_DIR)/character_select/mario_select.json
 	$(ASSET_EXTRACT) $(BASEROM) $<
 	touch $@
+
+.PHONY: distclean_mario_select
+distclean_mario_select:
+	rm -rf $(MARIO_SELECT_DIR)
+
+distclean_assets: distclean_mario_select

--- a/assets/include/character_select/peach_select.mk
+++ b/assets/include/character_select/peach_select.mk
@@ -21,8 +21,6 @@ $(PEACH_SELECT_DIR)/peach_face_16.png
 
 PEACH_SELECT_EXPORT_SENTINEL := $(PEACH_SELECT_DIR)/.export
 
-ASSET_DIRECTORIES += $(PEACH_SELECT_DIR)
-
 $(BUILD_DIR)/data/course_player_selection.o: $(PEACH_SELECT_PNG:%.png=%.mio0)
 
 $(PEACH_SELECT_PNG:%.png=%.mio0) : %.mio0 : %.bin
@@ -36,3 +34,9 @@ $(PEACH_SELECT_PNG): $(PEACH_SELECT_EXPORT_SENTINEL) ;
 $(PEACH_SELECT_EXPORT_SENTINEL): $(ASSET_DIR)/character_select/peach_select.json
 	$(ASSET_EXTRACT) $(BASEROM) $<
 	touch $@
+
+.PHONY: distclean_peach_select
+distclean_peach_select:
+	rm -rf $(PEACH_SELECT_DIR)
+
+distclean_assets: distclean_peach_select

--- a/assets/include/character_select/toad_select.mk
+++ b/assets/include/character_select/toad_select.mk
@@ -21,8 +21,6 @@ $(TOAD_SELECT_DIR)/toad_face_16.png
 
 TOAD_SELECT_EXPORT_SENTINEL := $(TOAD_SELECT_DIR)/.export
 
-ASSET_DIRECTORIES += $(TOAD_SELECT_DIR)
-
 $(BUILD_DIR)/data/course_player_selection.o: $(TOAD_SELECT_PNG:%.png=%.mio0)
 
 $(TOAD_SELECT_PNG:%.png=%.mio0) : %.mio0 : %.bin
@@ -36,3 +34,9 @@ $(TOAD_SELECT_PNG): $(TOAD_SELECT_EXPORT_SENTINEL) ;
 $(TOAD_SELECT_EXPORT_SENTINEL): $(ASSET_DIR)/character_select/toad_select.json
 	$(ASSET_EXTRACT) $(BASEROM) $<
 	touch $@
+
+.PHONY: distclean_toad_select
+distclean_toad_select:
+	rm -rf $(TOAD_SELECT_DIR)
+
+distclean_assets: distclean_toad_select

--- a/assets/include/character_select/wario_select.mk
+++ b/assets/include/character_select/wario_select.mk
@@ -21,8 +21,6 @@ $(WARIO_SELECT_DIR)/wario_face_16.png
 
 WARIO_SELECT_EXPORT_SENTINEL := $(WARIO_SELECT_DIR)/.export
 
-ASSET_DIRECTORIES += $(WARIO_SELECT_DIR)
-
 $(BUILD_DIR)/data/course_player_selection.o: $(WARIO_SELECT_PNG:%.png=%.mio0)
 
 $(WARIO_SELECT_PNG:%.png=%.mio0) : %.mio0 : %.bin
@@ -36,3 +34,9 @@ $(WARIO_SELECT_PNG): $(WARIO_SELECT_EXPORT_SENTINEL) ;
 $(WARIO_SELECT_EXPORT_SENTINEL): $(ASSET_DIR)/character_select/wario_select.json
 	$(ASSET_EXTRACT) $(BASEROM) $<
 	touch $@
+
+.PHONY: distclean_wario_select
+distclean_wario_select:
+	rm -rf $(WARIO_SELECT_DIR)
+
+distclean_assets: distclean_wario_select

--- a/assets/include/character_select/yoshi_select.mk
+++ b/assets/include/character_select/yoshi_select.mk
@@ -21,8 +21,6 @@ $(YOSHI_SELECT_DIR)/yoshi_face_16.png
 
 YOSHI_SELECT_EXPORT_SENTINEL := $(YOSHI_SELECT_DIR)/.export
 
-ASSET_DIRECTORIES += $(YOSHI_SELECT_DIR)
-
 $(BUILD_DIR)/data/course_player_selection.o: $(YOSHI_SELECT_PNG:%.png=%.mio0)
 
 $(YOSHI_SELECT_PNG:%.png=%.mio0) : %.mio0 : %.bin
@@ -36,3 +34,9 @@ $(YOSHI_SELECT_PNG): $(YOSHI_SELECT_EXPORT_SENTINEL) ;
 $(YOSHI_SELECT_EXPORT_SENTINEL): $(ASSET_DIR)/character_select/yoshi_select.json
 	$(ASSET_EXTRACT) $(BASEROM) $<
 	touch $@
+
+.PHONY: distclean_yoshi_select
+distclean_yoshi_select:
+	rm -rf $(YOSHI_SELECT_DIR)
+
+distclean_assets: distclean_yoshi_select

--- a/assets/include/courses/banshee_boardwalk.mk
+++ b/assets/include/courses/banshee_boardwalk.mk
@@ -46,8 +46,6 @@ $(BANSHEE_BOARDWALK_DIR)/gTextureBansheBoardwalkAA78.png
 
 BANSHEE_BOARDWALK_EXPORT_SENTINEL := $(BANSHEE_BOARDWALK_DIR)/.export
 
-ASSET_DIRECTORIES += $(BANSHEE_BOARDWALK_DIR)
-
 $(BUILD_DIR)/data/other_textures.o: $(BANSHEE_BOARDWALK_DIR)/boo_frames.mio0
 
 $(BANSHEE_BOARDWALK_DIR)/boo_frames.mio0: $(BANSHEE_BOARDWALK_DIR)/boo_frames.bin
@@ -82,3 +80,9 @@ $(BANSHEE_BOARDWALK_PNG): $(BANSHEE_BOARDWALK_EXPORT_SENTINEL) ;
 $(BANSHEE_BOARDWALK_EXPORT_SENTINEL): $(ASSET_DIR)/courses/banshee_boardwalk.json
 	$(ASSET_EXTRACT) $(BASEROM) $<
 	touch $@
+
+.PHONY: distclean_banshee_boardwalk
+distclean_banshee_boardwalk:
+	rm -rf $(BANSHEE_BOARDWALK_DIR)
+
+distclean_assets: distclean_banshee_boardwalk

--- a/assets/include/courses/bowsers_castle.mk
+++ b/assets/include/courses/bowsers_castle.mk
@@ -14,8 +14,6 @@ THOWMP_SIDE_PNG := $(BOWSERS_CASTLE_DIR)/gTextureThwompSide.png
 
 BOWSERS_CASTLE_EXPORT_SENTINEL := $(BOWSERS_CASTLE_DIR)/.export
 
-ASSET_DIRECTORIES += $(BOWSERS_CASTLE_DIR)
-
 $(BUILD_DIR)/courses/star_cup/bowsers_castle/course_data.inc.o: $(THWOMP_FACE_FRAMES:%.png=%.inc.c) $(THWOMP_PALETTE:%.png=%.inc.c)
 $(BUILD_DIR)/courses/star_cup/bowsers_castle/course_data.inc.o: $(THOWMP_SIDE_PNG:%.png=%.inc.c)
 
@@ -30,3 +28,9 @@ $(THWOMP_PALETTE) $(THWOMP_FACE_FRAMES) $(THOWMP_SIDE_PNG): $(BOWSERS_CASTLE_EXP
 $(BOWSERS_CASTLE_EXPORT_SENTINEL): $(ASSET_DIR)/courses/bowsers_castle.json
 	$(ASSET_EXTRACT) $(BASEROM) $<
 	touch $@
+
+.PHONY: distclean_bowsers_castle
+distclean_bowsers_castle:
+	rm -rf $(BOWSERS_CASTLE_DIR)
+
+distclean_assets: distclean_bowsers_castle

--- a/assets/include/courses/choco_mountain.mk
+++ b/assets/include/courses/choco_mountain.mk
@@ -6,8 +6,6 @@ $(CHOCO_MOUNTAIN_DIR)/gTextureChocoMountainRock.png
 
 CHOCO_MOUNTAIN_EXPORT_SENTINEL := $(CHOCO_MOUNTAIN_DIR)/.export
 
-ASSET_DIRECTORIES += $(CHOCO_MOUNTAIN_DIR)
-
 $(BUILD_DIR)/courses/flower_cup/choco_mountain/course_data.inc.o: $(CHOCO_MOUNTAIN_PNG:%.png=%.inc.c)
 
 $(CHOCO_MOUNTAIN_PNG:%.png=%.inc.c): %.inc.c : %.png
@@ -18,3 +16,9 @@ $(CHOCO_MOUNTAIN_PNG): $(CHOCO_MOUNTAIN_EXPORT_SENTINEL) ;
 $(CHOCO_MOUNTAIN_EXPORT_SENTINEL): $(ASSET_DIR)/courses/choco_mountain.json
 	$(ASSET_EXTRACT) $(BASEROM) $<
 	touch $@
+
+.PHONY: distclean_choco_mountain
+distclean_choco_mountain:
+	rm -rf $(CHOCO_MOUNTAIN_DIR)
+
+distclean_assets: distclean_choco_mountain

--- a/assets/include/courses/dks_jungle_parkway.mk
+++ b/assets/include/courses/dks_jungle_parkway.mk
@@ -24,8 +24,6 @@ $(DKS_JUNGLE_PARKWAY_DIR)/gTextureDksJungleParkwayKiwanoFruit3.png
 
 DKS_JUNGLE_PARKWAY_EXPORT_SENTINEL := $(DKS_JUNGLE_PARKWAY_DIR)/.export
 
-ASSET_DIRECTORIES += $(DKS_JUNGLE_PARKWAY_DIR)
-
 $(BUILD_DIR)/data/other_textures.o: $(DKS_JUNGLE_PARKWAY_KIWANO_FRAMES:%.png=%.mio0)
 
 $(DKS_JUNGLE_PARKWAY_KIWANO_FRAMES:%.png=%.mio0): %.mio0 : %.bin
@@ -46,3 +44,9 @@ $(DKS_JUNGLE_PARKWAY_PNG): $(DKS_JUNGLE_PARKWAY_EXPORT_SENTINEL) ;
 $(DKS_JUNGLE_PARKWAY_EXPORT_SENTINEL): $(ASSET_DIR)/courses/dks_jungle_parkway.json
 	$(ASSET_EXTRACT) $(BASEROM) $<
 	touch $@
+
+.PHONY: distclean_dks_junk_parkway
+distclean_dks_junk_parkway:
+	rm -rf $(DKS_JUNGLE_PARKWAY_DIR)
+
+distclean_assets: distclean_dks_junk_parkway

--- a/assets/include/courses/frappe_snowland.mk
+++ b/assets/include/courses/frappe_snowland.mk
@@ -1,8 +1,8 @@
 FRAPPE_SNOWLAND_DIR := assets/courses/frappe_snowland
 
 FRAPPE_SNOWLAND_SNOWMAN_PALETTE := $(FRAPPE_SNOWLAND_DIR)/gTLUTSnowman.png
-FRAPPE_SNOWLAND_SNOW_PALETTE    := $(FRAPPE_SNOWLAND_DIR)/gTLUTSnow.png
-FRAPPE_SNOWLAND_TREE_PALETTE    := $(FRAPPE_SNOWLAND_DIR)/gTLUTFrappeSnowlandTree.png
+FRAPPE_SNOWLAND_SNOW_PALETTE	:= $(FRAPPE_SNOWLAND_DIR)/gTLUTSnow.png
+FRAPPE_SNOWLAND_TREE_PALETTE	:= $(FRAPPE_SNOWLAND_DIR)/gTLUTFrappeSnowlandTree.png
 
 FRAPPE_SNOWLAND_SNOWMAN_PNG := \
 $(FRAPPE_SNOWLAND_DIR)/gTextureSnowmanHead.png \
@@ -16,8 +16,6 @@ $(FRAPPE_SNOWLAND_DIR)/gTextureFrappeSnowlandTreeLeft.png \
 $(FRAPPE_SNOWLAND_DIR)/gTextureFrappeSnowlandTreeRight.png \
 
 FRAPPE_SNOWLAND_EXPORT_SENTINEL := $(FRAPPE_SNOWLAND_DIR)/.export
-
-ASSET_DIRECTORIES += $(FRAPPE_SNOWLAND_DIR)
 
 $(BUILD_DIR)/courses/flower_cup/frappe_snowland/course_data.inc.o: $(FRAPPE_SNOWLAND_SNOWMAN_PNG:%.png=%.inc.c) $(FRAPPE_SNOWLAND_SNOW_PNG:%.png=%.inc.c)
 $(BUILD_DIR)/courses/flower_cup/frappe_snowland/course_data.inc.o: $(FRAPPE_SNOWLAND_SNOWMAN_PALETTE:%.png=%.inc.c) $(FRAPPE_SNOWLAND_SNOW_PALETTE:%.png=%.inc.c)
@@ -46,3 +44,9 @@ $(FRAPPE_SNOWLAND_SNOWMAN_PALETTE) $(FRAPPE_SNOWLAND_SNOW_PALETTE) $(FRAPPE_SNOW
 $(FRAPPE_SNOWLAND_EXPORT_SENTINEL): $(ASSET_DIR)/courses/frappe_snowland.json
 	$(ASSET_EXTRACT) $(BASEROM) $<
 	touch $@
+
+.PHONY: distclean_frappe_snowland
+distclean_frappe_snowland:
+	rm -rf $(FRAPPE_SNOWLAND_DIR)
+
+distclean_assets: distclean_frappe_snowland

--- a/assets/include/courses/kalimari_desert.mk
+++ b/assets/include/courses/kalimari_desert.mk
@@ -40,8 +40,6 @@ $(KALIMARI_DESERT_DIR)/gTextureLocomotiveBogie.png
 
 KALIMARI_DESERT_EXPORT_SENTINEL := $(KALIMARI_DESERT_DIR)/.export
 
-ASSET_DIRECTORIES += $(KALIMARI_DESERT_DIR)
-
 $(BUILD_DIR)/courses/mushroom_cup/kalimari_desert/course_data.inc.o: $(KALIMARI_DESERT_PNG:%.png=%.inc.c) $(CACTUS_PALETTE_IMPORT:%.png=%.inc.c)
 
 $(KALIMARI_DESERT_PNG:%.png=%.inc.c) $(CACTUS_PALETTE_IMPORT:%.png=%.inc.c): %.inc.c : %.png
@@ -61,3 +59,9 @@ $(KALIMARI_DESERT_PNG): $(KALIMARI_DESERT_EXPORT_SENTINEL) ;
 $(KALIMARI_DESERT_EXPORT_SENTINEL): $(ASSET_DIR)/courses/kalimari_desert.json
 	$(ASSET_EXTRACT) $(BASEROM) $<
 	touch $@
+
+.PHONY: distclean_kalimari_desert
+distclean_kalimari_desert:
+	rm -rf $(KALIMARI_DESERT_DIR)
+
+distclean_assets: distclean_kalimari_desert

--- a/assets/include/courses/koopa_troopa_beach.mk
+++ b/assets/include/courses/koopa_troopa_beach.mk
@@ -20,8 +20,6 @@ $(KOOPA_TROOPA_BEACH_DIR)/gTextureKoopaTroopaPalmTrunk.png
 
 KOOPA_TROOPA_BEACH_EXPORT_SENTINEL := $(KOOPA_TROOPA_BEACH_DIR)/.export
 
-ASSET_DIRECTORIES += $(KOOPA_TROOPA_BEACH_DIR)
-
 $(BUILD_DIR)/courses/mushroom_cup/koopa_troopa_beach/course_data.inc.o: $(KOOPA_TROOPA_BEACH_CRAB_PALETTE:%.png=%.inc.c) $(KOOPA_TROOPA_BEACH_CRAB_FRAMES:%.png=%.inc.c)
 $(BUILD_DIR)/courses/mushroom_cup/koopa_troopa_beach/course_data.inc.o: $(KOOPA_TROOPA_BEACH_PNG:%.png=%.inc.c)
 
@@ -36,3 +34,9 @@ $(KOOPA_TROOPA_BEACH_CRAB_PALETTE) $(KOOPA_TROOPA_BEACH_CRAB_FRAMES) $(KOOPA_TRO
 $(KOOPA_TROOPA_BEACH_EXPORT_SENTINEL): $(ASSET_DIR)/courses/koopa_troopa_beach.json
 	$(ASSET_EXTRACT) $(BASEROM) $<
 	touch $@
+
+.PHONY: distclean_koopa_troopa_beach
+distclean_koopa_troopa_beach:
+	rm -rf $(KOOPA_TROOPA_BEACH_DIR)
+
+distclean_assets: distclean_koopa_troopa_beach

--- a/assets/include/courses/luigi_raceway.mk
+++ b/assets/include/courses/luigi_raceway.mk
@@ -8,8 +8,6 @@ $(LUIGI_RACEWAY_DIR)/gTextureLuigiRacewayBalloonRope.png
 
 LUIGI_RACEWAY_EXPORT_SENTINEL := $(LUIGI_RACEWAY_DIR)/.export
 
-ASSET_DIRECTORIES += $(LUIGI_RACEWAY_DIR)
-
 $(BUILD_DIR)/courses/mushroom_cup/luigi_raceway/course_data.inc.o: $(LUIGI_RACEWAY_PNG:%.png=%.inc.c)
 
 $(LUIGI_RACEWAY_PNG:%.png=%.inc.c): %.inc.c : %.png
@@ -20,3 +18,9 @@ $(LUIGI_RACEWAY_PNG): $(LUIGI_RACEWAY_EXPORT_SENTINEL) ;
 $(LUIGI_RACEWAY_EXPORT_SENTINEL): $(ASSET_DIR)/courses/luigi_raceway.json
 	$(ASSET_EXTRACT) $(BASEROM) $<
 	touch $@
+
+.PHONY: distclean_luigi_raceway
+distclean_luigi_raceway:
+	rm -rf $(LUIGI_RACEWAY_DIR)
+
+distclean_assets: distclean_luigi_raceway

--- a/assets/include/courses/mario_raceway.mk
+++ b/assets/include/courses/mario_raceway.mk
@@ -19,8 +19,6 @@ $(MARIO_RACEWAY_DIR)/gTextureMarioRacewaySignRight.png
 
 PIRANHA_PLANT_EXPORT_SENTINEL := $(MARIO_RACEWAY_DIR)/.export
 
-ASSET_DIRECTORIES += $(MARIO_RACEWAY_DIR)
-
 $(BUILD_DIR)/$(DATA_DIR)/other_textures.o: $(PIRANHA_PLANT_FRAMES:%.png=%.mio0)
 
 $(PIRANHA_PLANT_FRAMES:%.png=%.mio0): %.mio0 : %.bin
@@ -39,3 +37,9 @@ $(PIRANHA_PLANT_FRAMES) $(MARIO_RACEWAY_PIRANHA_PLANT_PALETTE) $(MARIO_RACEWAY_S
 $(PIRANHA_PLANT_EXPORT_SENTINEL): $(ASSET_DIR)/courses/mario_raceway.json
 	$(ASSET_EXTRACT) $(BASEROM) $<
 	touch $@
+
+.PHONY: distclean_mario_raceway
+distclean_mario_raceway:
+	rm -rf $(MARIO_RACEWAY_DIR)
+
+distclean_assets: distclean_mario_raceway

--- a/assets/include/courses/moo_moo_farm.mk
+++ b/assets/include/courses/moo_moo_farm.mk
@@ -39,8 +39,6 @@ MOO_MOO_FARM_DIRT_PNG := $(MOO_MOO_FARM_DIR)/gTextureMooMooFarmDirt.png
 
 MOO_MOO_FARM_EXPORT_SENTINEL := $(MOO_MOO_FARM_DIR)/.export
 
-ASSET_DIRECTORIES += $(MOO_MOO_FARM_DIR)
-
 $(BUILD_DIR)/courses/mushroom_cup/moo_moo_farm/course_data.inc.o: $(MOLE_PALETTE:%.png=%.inc.c) $(MOLE_FRAMES:%.png=%.inc.c)
 $(BUILD_DIR)/courses/mushroom_cup/moo_moo_farm/course_data.inc.o: $(COW_PALETTE_IMPORT:%.png=%.inc.c)
 $(BUILD_DIR)/courses/mushroom_cup/moo_moo_farm/course_data.inc.o: $(MOO_MOO_FARM_DIRT_PNG:%.png=%.inc.c)
@@ -72,3 +70,9 @@ $(MOO_MOO_FARM_SIGN_PNG) $(MOO_MOO_FARM_DIRT_PNG): $(MOO_MOO_FARM_EXPORT_SENTINE
 $(MOO_MOO_FARM_EXPORT_SENTINEL): $(ASSET_DIR)/courses/moo_moo_farm.json
 	$(ASSET_EXTRACT) $(BASEROM) $<
 	touch $@
+
+.PHONY: distclean_moo_moo_farm
+distclean_moo_moo_farm:
+	rm -rf $(MOO_MOO_FARM_DIR)
+
+distclean_assets: distclean_moo_moo_farm

--- a/assets/include/courses/rainbow_road.mk
+++ b/assets/include/courses/rainbow_road.mk
@@ -54,8 +54,6 @@ $(RAINBOW_ROAD_DIR)/gTextureRainbowRoadChainChompEye.png
 
 RAINBOW_ROAD_EXPORT_SENTINEL := $(RAINBOW_ROAD_DIR)/.export
 
-ASSET_DIRECTORIES += $(RAINBOW_ROAD_DIR)
-
 $(BUILD_DIR)/courses/special_cup/rainbow_road/course_data.inc.o: $(RAINBOW_ROAD_MUSHROOM_PNG:%.png=%.inc.c)
 $(BUILD_DIR)/courses/special_cup/rainbow_road/course_data.inc.o: $(RAINBOW_ROAD_MARIO_PNG:%.png=%.inc.c)
 $(BUILD_DIR)/courses/special_cup/rainbow_road/course_data.inc.o: $(RAINBOW_ROAD_BOO_PNG:%.png=%.inc.c)
@@ -102,3 +100,9 @@ $(RAINBOW_ROAD_PNG): $(RAINBOW_ROAD_EXPORT_SENTINEL) ;
 $(RAINBOW_ROAD_EXPORT_SENTINEL): $(ASSET_DIR)/courses/rainbow_road.json
 	$(ASSET_EXTRACT) $(BASEROM) $<
 	touch $@
+
+.PHONY: distclean_rainbow_road
+distclean_rainbow_road:
+	rm -rf $(RAINBOW_ROAD_DIR)
+
+distclean_assets: distclean_rainbow_road

--- a/assets/include/courses/royal_raceway.mk
+++ b/assets/include/courses/royal_raceway.mk
@@ -4,8 +4,6 @@ ROYAL_RACEWAY_PIRANHA_PLANT_PALETTE := $(ROYAL_RACEWAY_DIR)/gTLUTRoyalRacewayPir
 
 ROYAL_RACEWAY_EXPORT_SENTINEL := $(ROYAL_RACEWAY_DIR)/.export
 
-ASSET_DIRECTORIES += $(ROYAL_RACEWAY_DIR)
-
 $(BUILD_DIR)/courses/star_cup/royal_raceway/course_data.inc.o: $(ROYAL_RACEWAY_PIRANHA_PLANT_PALETTE:%.png=%.inc.c)
 
 $(ROYAL_RACEWAY_PIRANHA_PLANT_PALETTE:%.png=%.inc.c): %.inc.c : %.png
@@ -16,3 +14,9 @@ $(ROYAL_RACEWAY_PIRANHA_PLANT_PALETTE): $(ROYAL_RACEWAY_EXPORT_SENTINEL) ;
 $(ROYAL_RACEWAY_EXPORT_SENTINEL): $(ASSET_DIR)/courses/royal_raceway.json
 	$(ASSET_EXTRACT) $(BASEROM) $<
 	touch $@
+
+.PHONY: distclean_royal_raceway
+distclean_royal_raceway:
+	rm -rf $(ROYAL_RACEWAY_DIR)
+
+distclean_assets: distclean_royal_raceway

--- a/assets/include/courses/sherbet_land.mk
+++ b/assets/include/courses/sherbet_land.mk
@@ -8,8 +8,6 @@ $(SHERBET_LAND_DIR)/gTexturePenguinEye.png
 
 SHERBET_LAND_EXPORT_SENTINEL := $(SHERBET_LAND_DIR)/.export
 
-ASSET_DIRECTORIES += $(SHERBET_LAND_DIR)
-
 $(BUILD_DIR)/courses/star_cup/sherbet_land/course_data.inc.o: $(SHERBET_LAND_ICE:%.png=%.inc.c) $(PENGUIN_PNG:%.png=%.inc.c)
 
 $(SHERBET_LAND_ICE:%.png=%.inc.c): %.inc.c : %.png
@@ -23,3 +21,9 @@ $(SHERBET_LAND_PNG) $(PENGUIN_PNG) $(SHERBET_LAND_ICE): $(SHERBET_LAND_EXPORT_SE
 $(SHERBET_LAND_EXPORT_SENTINEL): $(ASSET_DIR)/courses/sherbet_land.json
 	$(ASSET_EXTRACT) $(BASEROM) $<
 	touch $@
+
+.PHONY: distclean_sherbet_land
+distclean_sherbet_land:
+	rm -rf $(SHERBET_LAND_DIR)
+
+distclean_assets: distclean_sherbet_land

--- a/assets/include/courses/toads_turnpike.mk
+++ b/assets/include/courses/toads_turnpike.mk
@@ -38,8 +38,6 @@ $(TOADS_TURNPIKE_DIR)/gTextureToadsTurnpikeCarSideLod1.png
 
 TOADS_TURNPIKE_EXPORT_SENTINEL := $(TOADS_TURNPIKE_DIR)/.export
 
-ASSET_DIRECTORIES += $(TOADS_TURNPIKE_DIR)
-
 $(BUILD_DIR)/courses/flower_cup/toads_turnpike/course_data.inc.o: $(TOADS_TURNPIKE_PNG:%.png=%.inc.c)
 
 $(TOADS_TURNPIKE_PNG:%.png=%.inc.c): %.inc.c : %.png
@@ -50,3 +48,9 @@ $(TOADS_TURNPIKE_PNG): $(TOADS_TURNPIKE_EXPORT_SENTINEL) ;
 $(TOADS_TURNPIKE_EXPORT_SENTINEL): $(ASSET_DIR)/courses/toads_turnpike.json
 	$(ASSET_EXTRACT) $(BASEROM) $<
 	touch $@
+
+.PHONY: distclean_toads_turnpike
+distclean_toads_turnpike:
+	rm -rf $(TOADS_TURNPIKE_DIR)
+
+distclean_assets: distclean_toads_turnpike

--- a/assets/include/courses/wario_stadium.mk
+++ b/assets/include/courses/wario_stadium.mk
@@ -1,14 +1,12 @@
 WARIO_STADIUM_DIR := assets/courses/wario_stadium
 
 WARIO_STADIUM_SIGN := \
-$(WARIO_STADIUM_DIR)/gTextureWarioStadiumSignTopLeft.png    \
+$(WARIO_STADIUM_DIR)/gTextureWarioStadiumSignTopLeft.png	\
 $(WARIO_STADIUM_DIR)/gTextureWarioStadiumSignBottomLeft.png \
 $(WARIO_STADIUM_DIR)/gTextureWarioStadiumSignTopRight.png   \
 $(WARIO_STADIUM_DIR)/gTextureWarioStadiumSignBottomRight.png
 
 WARIO_STADIUM_EXPORT_SENTINEL := $(WARIO_STADIUM_DIR)/.export
-
-ASSET_DIRECTORIES += $(WARIO_STADIUM_DIR)
 
 $(BUILD_DIR)/courses/star_cup/wario_stadium/course_data.inc.o: $(WARIO_STADIUM_SIGN:%.png=%.inc.c)
 
@@ -20,3 +18,9 @@ $(WARIO_STADIUM_SIGN): $(WARIO_STADIUM_EXPORT_SENTINEL) ;
 $(WARIO_STADIUM_EXPORT_SENTINEL): $(ASSET_DIR)/courses/wario_stadium.json
 	$(ASSET_EXTRACT) $(BASEROM) $<
 	touch $@
+
+.PHONY: distclean_wario_stadium
+distclean_wario_stadium:
+	rm -rf $(WARIO_STADIUM_DIR)
+
+distclean_assets: distclean_wario_stadium

--- a/assets/include/courses/yoshi_valley.mk
+++ b/assets/include/courses/yoshi_valley.mk
@@ -6,11 +6,9 @@ $(YOSHI_VALLEY_DIR)/gTextureYoshiValleyEggSpot.png \
 $(YOSHI_VALLEY_DIR)/gTextureYoshiValleyEgg.png
 
 YOSHI_VALLEY_HEDGEHOG_PALETTE := $(YOSHI_VALLEY_DIR)/gTLUTYoshiValleyHedgehog.png
-YOSHI_VALLEY_HEDGEHOG_PNG     := $(YOSHI_VALLEY_DIR)/gTextureYoshiValleyHedgehog.png
+YOSHI_VALLEY_HEDGEHOG_PNG	 := $(YOSHI_VALLEY_DIR)/gTextureYoshiValleyHedgehog.png
 
 YOSHI_VALLEY_EXPORT_SENTINEL := $(YOSHI_VALLEY_DIR)/.export
-
-ASSET_DIRECTORIES += $(YOSHI_VALLEY_DIR)
 
 $(BUILD_DIR)/courses/special_cup/yoshi_valley/course_data.inc.o: $(YOSHI_VALLEY_HEDGEHOG_PALETTE:%.png=%.inc.c) $(YOSHI_VALLEY_HEDGEHOG_PNG:%.png=%.inc.c)
 $(BUILD_DIR)/courses/special_cup/yoshi_valley/course_data.inc.o: $(YOSHI_VALLEY_PNG:%.png=%.inc.c)
@@ -27,3 +25,9 @@ $(YOSHI_VALLEY_PNG): $(YOSHI_VALLEY_EXPORT_SENTINEL) ;
 $(YOSHI_VALLEY_EXPORT_SENTINEL): $(ASSET_DIR)/courses/yoshi_valley.json
 	$(ASSET_EXTRACT) $(BASEROM) $<
 	touch $@
+
+.PHONY: distclean_yoshi_valley
+distclean_yoshi_valley:
+	rm -rf $(YOSHI_VALLEY_DIR)
+
+distclean_assets: distclean_yoshi_valley

--- a/assets/include/finish_line_banner.mk
+++ b/assets/include/finish_line_banner.mk
@@ -14,8 +14,6 @@ $(FINISH_LINE_BANNER_DIR)/gTextureFinishLineBanner8.png
 
 FINISH_LINE_BANNER_EXPORT_SENTINEL := $(FINISH_LINE_BANNER_DIR)/.export
 
-ASSET_DIRECTORIES += $(FINISH_LINE_BANNER_DIR)
-
 $(BUILD_DIR)/$(DATA_DIR)/other_textures.o: $(FINISH_LINE_BANNER_PNG:%.png=%.mio0)
 
 $(FINISH_LINE_BANNER_PNG:%.png=%.mio0): %.mio0 : %.bin
@@ -34,3 +32,9 @@ $(FINISH_LINE_BANNER_PNG) $(FINISH_LINE_BANNER_PALETTE): $(FINISH_LINE_BANNER_EX
 $(FINISH_LINE_BANNER_EXPORT_SENTINEL): $(ASSET_DIR)/finish_line_banner.json
 	$(ASSET_EXTRACT) $(BASEROM) $<
 	touch $@
+
+.PHONY: distclean_finish_line_banner
+distclean_finish_line_banner:
+	rm -rf $(FINISH_LINE_BANNER_DIR)
+
+distclean_assets: distclean_finish_line_banner

--- a/assets/include/greenshell.mk
+++ b/assets/include/greenshell.mk
@@ -14,8 +14,6 @@ $(GREENSHELL_DIR)/gTextureGreenShell08.png
 
 GREENSHELL_EXPORT_SENTINEL := $(GREENSHELL_DIR)/.export
 
-ASSET_DIRECTORIES += $(GREENSHELL_DIR)
-
 $(GREENSHELL_FRAMES:%.png=%.inc.c): %.inc.c : %.png
 	$(N64GRAPHICS) -Z $@ -g $< -s u8 -f ci8 -c rgba16 -p $(GREENSHELL_PALETTE)
 
@@ -29,3 +27,9 @@ $(GREENSHELL_FRAMES) $(GREENSHELL_PALETTE): $(GREENSHELL_EXPORT_SENTINEL) ;
 $(GREENSHELL_EXPORT_SENTINEL): $(ASSET_DIR)/greenshell.json
 	$(ASSET_EXTRACT) $(BASEROM) $<
 	touch $@
+
+.PHONY: distclean_greenshell
+distclean_greenshell:
+	rm -rf $(GREENSHELL_DIR)
+
+distclean_assets: distclean_greenshell

--- a/assets/include/item_window.mk
+++ b/assets/include/item_window.mk
@@ -38,8 +38,6 @@ $(ITEM_WINDOW_DIR)/gTextureItemWindowFakeItemBox.png
 
 ITEM_WINDOW_EXPORT_SENTINEL := $(ITEM_WINDOW_DIR)/.export
 
-ASSET_DIRECTORIES += $(ITEM_WINDOW_DIR)
-
 $(BUILD_DIR)/src/common_textures.inc.o: $(ITEM_WINDOW_PNG:%.png=%.inc.c) $(ITEM_WINDOW_PALETTES:%.png=%.inc.c)
 
 $(ITEM_WINDOW_DIR)/gTexture%.inc.c: $(ITEM_WINDOW_DIR)/gTexture%.png
@@ -53,3 +51,9 @@ $(ITEM_WINDOW_PNG) $(ITEM_WINDOW_PALETTES): $(ITEM_WINDOW_EXPORT_SENTINEL) ;
 $(ITEM_WINDOW_EXPORT_SENTINEL): $(ASSET_DIR)/item_window.json
 	$(ASSET_EXTRACT) $(BASEROM) $<
 	touch $@
+
+.PHONY: distclean_item_window
+distclean_item_window:
+	rm -rf $(ITEM_WINDOW_DIR)
+
+distclean_assets: distclean_item_window

--- a/assets/include/karts/bowser_kart.mk
+++ b/assets/include/karts/bowser_kart.mk
@@ -1484,8 +1484,6 @@ BOWSER_KART_PALETTE_PNG := \
 
 BOWSER_EXPORT_SENTINEL := $(BOWSER_KART_DIR)/.export
 
-ASSET_DIRECTORIES += $(BOWSER_KART_DIR)
-
 $(BUILD_DIR)/$(DATA_DIR)/karts/bowser_kart.o: $(BOWSER_KART_FRAME_PNG:%.png=%.mio0) $(BOWSER_KART_PALETTE_PNG:%.png=%.bin)
 
 $(BOWSER_KART_FRAME_PNG:%.png=%.mio0): %.mio0 : %.bin
@@ -1502,3 +1500,9 @@ $(BOWSER_KART_FRAME_PNG) $(BOWSER_KART_PALETTE_PNG): $(BOWSER_EXPORT_SENTINEL) ;
 $(BOWSER_EXPORT_SENTINEL): $(ASSET_DIR)/karts/bowser_kart.json
 	$(ASSET_EXTRACT) $(BASEROM) $<
 	touch $@
+
+.PHONY: distclean_bowser_kart
+distclean_bowser_kart:
+	rm -rf $(BOWSER_KART_DIR)
+
+distclean_assets: distclean_bowser_kart

--- a/assets/include/karts/donkeykong_kart.mk
+++ b/assets/include/karts/donkeykong_kart.mk
@@ -1484,8 +1484,6 @@ DONKEYKONG_KART_PALETTE_PNG := \
 
 DONKEYKONG_EXPORT_SENTINEL := $(DONKEYKONG_KART_DIR)/.export
 
-ASSET_DIRECTORIES += $(DONKEYKONG_KART_DIR)
-
 $(BUILD_DIR)/$(DATA_DIR)/karts/donkeykong_kart.o: $(DONKEYKONG_KART_FRAME_PNG:%.png=%.mio0) $(DONKEYKONG_KART_PALETTE_PNG:%.png=%.bin)
 
 $(DONKEYKONG_KART_FRAME_PNG:%.png=%.mio0): %.mio0 : %.bin
@@ -1502,3 +1500,9 @@ $(DONKEYKONG_KART_FRAME_PNG) $(DONKEYKONG_KART_PALETTE_PNG): $(DONKEYKONG_EXPORT
 $(DONKEYKONG_EXPORT_SENTINEL): $(ASSET_DIR)/karts/donkeykong_kart.json
 	$(ASSET_EXTRACT) $(BASEROM) $<
 	touch $@
+
+.PHONY: distclean_donkeykong_kart
+distclean_donkeykong_kart:
+	rm -rf $(DONKEYKONG_KART_DIR)
+
+distclean_assets: distclean_donkeykong_kart

--- a/assets/include/karts/luigi_kart.mk
+++ b/assets/include/karts/luigi_kart.mk
@@ -1484,8 +1484,6 @@ LUIGI_KART_PALETTE_PNG := \
 
 LUIGI_EXPORT_SENTINEL := $(LUIGI_KART_DIR)/.export
 
-ASSET_DIRECTORIES += $(LUIGI_KART_DIR)
-
 $(BUILD_DIR)/$(DATA_DIR)/karts/luigi_kart.o: $(LUIGI_KART_FRAME_PNG:%.png=%.mio0) $(LUIGI_KART_PALETTE_PNG:%.png=%.bin)
 
 $(LUIGI_KART_FRAME_PNG:%.png=%.mio0): %.mio0 : %.bin
@@ -1502,3 +1500,9 @@ $(LUIGI_KART_FRAME_PNG) $(LUIGI_KART_PALETTE_PNG): $(LUIGI_EXPORT_SENTINEL) ;
 $(LUIGI_EXPORT_SENTINEL): $(ASSET_DIR)/karts/luigi_kart.json
 	$(ASSET_EXTRACT) $(BASEROM) $<
 	touch $@
+
+.PHONY: distclean_luigi_kart
+distclean_luigi_kart:
+	rm -rf $(LUIGI_KART_DIR)
+
+distclean_assets: distclean_luigi_kart

--- a/assets/include/karts/mario_kart.mk
+++ b/assets/include/karts/mario_kart.mk
@@ -1484,8 +1484,6 @@ MARIO_KART_PALETTE_PNG := \
 
 MARIO_EXPORT_SENTINEL := $(MARIO_KART_DIR)/.export
 
-ASSET_DIRECTORIES += $(MARIO_KART_DIR)
-
 $(BUILD_DIR)/$(DATA_DIR)/karts/mario_kart.o: $(MARIO_KART_FRAME_PNG:%.png=%.mio0) $(MARIO_KART_PALETTE_PNG:%.png=%.bin)
 
 $(MARIO_KART_FRAME_PNG:%.png=%.mio0): %.mio0 : %.bin
@@ -1502,3 +1500,9 @@ $(MARIO_KART_FRAME_PNG) $(MARIO_KART_PALETTE_PNG): $(MARIO_EXPORT_SENTINEL) ;
 $(MARIO_EXPORT_SENTINEL): $(ASSET_DIR)/karts/mario_kart.json
 	$(ASSET_EXTRACT) $(BASEROM) $<
 	touch $@
+
+.PHONY: distclean_mario_kart
+distclean_mario_kart:
+	rm -rf $(MARIO_KART_DIR)
+
+distclean_assets: distclean_mario_kart

--- a/assets/include/karts/peach_kart.mk
+++ b/assets/include/karts/peach_kart.mk
@@ -1484,8 +1484,6 @@ PEACH_KART_PALETTE_PNG := \
 
 PEACH_EXPORT_SENTINEL := $(PEACH_KART_DIR)/.export
 
-ASSET_DIRECTORIES += $(PEACH_KART_DIR)
-
 $(BUILD_DIR)/$(DATA_DIR)/karts/peach_kart.o: $(PEACH_KART_FRAME_PNG:%.png=%.mio0) $(PEACH_KART_PALETTE_PNG:%.png=%.bin)
 
 $(PEACH_KART_FRAME_PNG:%.png=%.mio0): %.mio0 : %.bin
@@ -1502,3 +1500,9 @@ $(PEACH_KART_FRAME_PNG) $(PEACH_KART_PALETTE_PNG): $(PEACH_EXPORT_SENTINEL) ;
 $(PEACH_EXPORT_SENTINEL): $(ASSET_DIR)/karts/peach_kart.json
 	$(ASSET_EXTRACT) $(BASEROM) $<
 	touch $@
+
+.PHONY: distclean_peach_kart
+distclean_peach_kart:
+	rm -rf $(PEACH_KART_DIR)
+
+distclean_assets: distclean_peach_kart

--- a/assets/include/karts/toad_kart.mk
+++ b/assets/include/karts/toad_kart.mk
@@ -1484,8 +1484,6 @@ TOAD_KART_PALETTE_PNG := \
 
 TOAD_EXPORT_SENTINEL := $(TOAD_KART_DIR)/.export
 
-ASSET_DIRECTORIES += $(TOAD_KART_DIR)
-
 $(BUILD_DIR)/$(DATA_DIR)/karts/toad_kart.o: $(TOAD_KART_FRAME_PNG:%.png=%.mio0) $(TOAD_KART_PALETTE_PNG:%.png=%.bin)
 
 $(TOAD_KART_FRAME_PNG:%.png=%.mio0): %.mio0 : %.bin
@@ -1502,3 +1500,9 @@ $(TOAD_KART_FRAME_PNG) $(TOAD_KART_PALETTE_PNG): $(TOAD_EXPORT_SENTINEL) ;
 $(TOAD_EXPORT_SENTINEL): $(ASSET_DIR)/karts/toad_kart.json
 	$(ASSET_EXTRACT) $(BASEROM) $<
 	touch $@
+
+.PHONY: distclean_toad_kart
+distclean_toad_kart:
+	rm -rf $(TOAD_KART_DIR)
+
+distclean_assets: distclean_toad_kart

--- a/assets/include/karts/wario_kart.mk
+++ b/assets/include/karts/wario_kart.mk
@@ -1484,8 +1484,6 @@ WARIO_KART_PALETTE_PNG := \
 
 WARIO_EXPORT_SENTINEL := $(WARIO_KART_DIR)/.export
 
-ASSET_DIRECTORIES += $(WARIO_KART_DIR)
-
 $(BUILD_DIR)/$(DATA_DIR)/karts/wario_kart.o: $(WARIO_KART_FRAME_PNG:%.png=%.mio0) $(WARIO_KART_PALETTE_PNG:%.png=%.bin)
 
 $(WARIO_KART_FRAME_PNG:%.png=%.mio0): %.mio0 : %.bin
@@ -1502,3 +1500,9 @@ $(WARIO_KART_FRAME_PNG) $(WARIO_KART_PALETTE_PNG): $(WARIO_EXPORT_SENTINEL) ;
 $(WARIO_EXPORT_SENTINEL): $(ASSET_DIR)/karts/wario_kart.json
 	$(ASSET_EXTRACT) $(BASEROM) $<
 	touch $@
+
+.PHONY: distclean_wario_kart
+distclean_wario_kart:
+	rm -rf $(WARIO_KART_DIR)
+
+distclean_assets: distclean_wario_kart

--- a/assets/include/karts/yoshi_kart.mk
+++ b/assets/include/karts/yoshi_kart.mk
@@ -1484,8 +1484,6 @@ YOSHI_KART_PALETTE_PNG := \
 
 YOSHI_EXPORT_SENTINEL := $(YOSHI_KART_DIR)/.export
 
-ASSET_DIRECTORIES += $(YOSHI_KART_DIR)
-
 $(BUILD_DIR)/$(DATA_DIR)/karts/yoshi_kart.o: $(YOSHI_KART_FRAME_PNG:%.png=%.mio0) $(YOSHI_KART_PALETTE_PNG:%.png=%.bin)
 
 $(YOSHI_KART_FRAME_PNG:%.png=%.mio0): %.mio0 : %.bin
@@ -1502,3 +1500,9 @@ $(YOSHI_KART_FRAME_PNG) $(YOSHI_KART_PALETTE_PNG): $(YOSHI_EXPORT_SENTINEL) ;
 $(YOSHI_EXPORT_SENTINEL): $(ASSET_DIR)/karts/yoshi_kart.json
 	$(ASSET_EXTRACT) $(BASEROM) $<
 	touch $@
+
+.PHONY: distclean_yoshi_kart
+distclean_yoshi_kart:
+	rm -rf $(YOSHI_KART_DIR)
+
+distclean_assets: distclean_yoshi_kart

--- a/assets/include/lakitu/bluelight.mk
+++ b/assets/include/lakitu/bluelight.mk
@@ -14,8 +14,6 @@ $(BLUELIGHT_DIR)/gTextureLakituBlueLight8.png
 
 BLUELIGHT_EXPORT_SENTINEL := $(BLUELIGHT_DIR)/.export
 
-ASSET_DIRECTORIES += $(BLUELIGHT_DIR)
-
 $(BLUELIGHT_FRAMES:%.png=%.inc.c): %.inc.c : %.png
 	$(N64GRAPHICS) -Z $@ -g $< -s u8 -f ci8 -c rgba16 -p $(BLUELIGHT_PALETTE)
 
@@ -29,3 +27,9 @@ $(BLUELIGHT_FRAMES) $(BLUELIGHT_PALETTE): $(BLUELIGHT_EXPORT_SENTINEL) ;
 $(BLUELIGHT_EXPORT_SENTINEL): assets/lakitu/bluelight.json
 	$(ASSET_EXTRACT) $(BASEROM) $<
 	touch $@
+
+.PHONY: distclean_lakitu_bluelight
+distclean_lakitu_bluelight:
+	rm -rf $(BLUELIGHT_DIR)
+
+distclean_assets: distclean_lakitu_bluelight

--- a/assets/include/lakitu/checkeredflag.mk
+++ b/assets/include/lakitu/checkeredflag.mk
@@ -38,8 +38,6 @@ $(CHECKEREDFLAG_DIR)/gTextureLakituCheckeredFlag32.png
 
 CHECKEREDFLAG_EXPORT_SENTINEL := $(CHECKEREDFLAG_DIR)/.export
 
-ASSET_DIRECTORIES += $(CHECKEREDFLAG_DIR)
-
 $(CHECKEREDFLAG_FRAMES:%.png=%.inc.c): %.inc.c : %.png
 	$(N64GRAPHICS) -Z $@ -g $< -s u8 -f ci8 -c rgba16 -p $(CHECKEREDFLAG_PALETTE)
 
@@ -53,3 +51,9 @@ $(CHECKEREDFLAG_FRAMES) $(CHECKEREDFLAG_PALETTE): $(CHECKEREDFLAG_EXPORT_SENTINE
 $(CHECKEREDFLAG_EXPORT_SENTINEL): assets/lakitu/checkeredflag.json
 	$(ASSET_EXTRACT) $(BASEROM) $<
 	touch $@
+
+.PHONY: distclean_lakitu_checkeredflag
+distclean_lakitu_checkeredflag:
+	rm -rf $(CHECKEREDFLAG_DIR)
+
+distclean_assets: distclean_lakitu_checkeredflag

--- a/assets/include/lakitu/finallap.mk
+++ b/assets/include/lakitu/finallap.mk
@@ -22,8 +22,6 @@ $(FINALLAP_DIR)/gTextureLakituFinalLap16.png
 
 FINALLAP_EXPORT_SENTINEL := $(FINALLAP_DIR)/.export
 
-ASSET_DIRECTORIES += $(FINALLAP_DIR)
-
 $(FINALLAP_FRAMES:%.png=%.inc.c): %.inc.c : %.png
 	$(N64GRAPHICS) -Z $@ -g $< -s u8 -f ci8 -c rgba16 -p $(FINALLAP_PALETTE)
 
@@ -37,3 +35,9 @@ $(FINALLAP_FRAMES) $(FINALLAP_PALETTE): $(FINALLAP_EXPORT_SENTINEL) ;
 $(FINALLAP_EXPORT_SENTINEL): assets/lakitu/finallap.json
 	$(ASSET_EXTRACT) $(BASEROM) $<
 	touch $@
+
+.PHONY: distclean_lakitu_finallap
+distclean_lakitu_finallap:
+	rm -rf $(FINALLAP_DIR)
+
+distclean_assets: distclean_lakitu_finallap

--- a/assets/include/lakitu/fishing.mk
+++ b/assets/include/lakitu/fishing.mk
@@ -10,8 +10,6 @@ $(FISHING_DIR)/gTextureLakituFishing4.png
 
 FISHING_EXPORT_SENTINEL := $(FISHING_DIR)/.export
 
-ASSET_DIRECTORIES += $(FISHING_DIR)
-
 $(FISHING_FRAMES:%.png=%.inc.c): %.inc.c : %.png
 	$(N64GRAPHICS) -Z $@ -g $< -s u8 -f ci8 -c rgba16 -p $(FISHING_PALETTE)
 
@@ -25,3 +23,9 @@ $(FISHING_FRAMES) $(FISHING_PALETTE): $(FISHING_EXPORT_SENTINEL) ;
 $(FISHING_EXPORT_SENTINEL): assets/lakitu/fishing.json
 	$(ASSET_EXTRACT) $(BASEROM) $<
 	touch $@
+
+.PHONY: distclean_lakitu_fishing
+distclean_lakitu_fishing:
+	rm -rf $(FISHING_DIR)
+
+distclean_assets: distclean_lakitu_fishing

--- a/assets/include/lakitu/nolights.mk
+++ b/assets/include/lakitu/nolights.mk
@@ -14,8 +14,6 @@ $(NOLIGHTS_DIR)/gTextureLakituNoLights8.png
 
 NOLIGHTS_EXPORT_SENTINEL := $(NOLIGHTS_DIR)/.export
 
-ASSET_DIRECTORIES += $(NOLIGHTS_DIR)
-
 $(NOLIGHTS_FRAMES:%.png=%.inc.c): %.inc.c : %.png
 	$(N64GRAPHICS) -Z $@ -g $< -s u8 -f ci8 -c rgba16 -p $(NOLIGHTS_PALETTE)
 
@@ -29,3 +27,9 @@ $(NOLIGHTS_FRAMES) $(NOLIGHTS_PALETTE): $(NOLIGHTS_EXPORT_SENTINEL) ;
 $(NOLIGHTS_EXPORT_SENTINEL): assets/lakitu/nolights.json
 	$(ASSET_EXTRACT) $(BASEROM) $<
 	touch $@
+
+.PHONY: distclean_lakitu_nolights
+distclean_lakitu_nolights:
+	rm -rf $(NOLIGHTS_DIR)
+
+distclean_assets: distclean_lakitu_nolights

--- a/assets/include/lakitu/redlights.mk
+++ b/assets/include/lakitu/redlights.mk
@@ -22,8 +22,6 @@ $(REDLIGHTS_DIR)/gTextureLakituRedLights16.png
 
 REDLIGHTS_EXPORT_SENTINEL := $(REDLIGHTS_DIR)/.export
 
-ASSET_DIRECTORIES += $(REDLIGHTS_DIR)
-
 $(REDLIGHTS_FRAMES:%.png=%.inc.c): %.inc.c : %.png
 	$(N64GRAPHICS) -Z $@ -g $< -s u8 -f ci8 -c rgba16 -p $(REDLIGHTS_PALETTE)
 
@@ -37,3 +35,9 @@ $(REDLIGHTS_FRAMES) $(REDLIGHTS_PALETTE): $(REDLIGHTS_EXPORT_SENTINEL) ;
 $(REDLIGHTS_EXPORT_SENTINEL): assets/lakitu/redlights.json
 	$(ASSET_EXTRACT) $(BASEROM) $<
 	touch $@
+
+.PHONY: distclean_lakitu_redlights
+distclean_lakitu_redlights:
+	rm -rf $(REDLIGHTS_DIR)
+
+distclean_assets: distclean_lakitu_redlights

--- a/assets/include/lakitu/reverse.mk
+++ b/assets/include/lakitu/reverse.mk
@@ -22,8 +22,6 @@ $(REVERSE_DIR)/gTextureLakituReverse16.png
 
 REVERSE_EXPORT_SENTINEL := $(REVERSE_DIR)/.export
 
-ASSET_DIRECTORIES += $(REVERSE_DIR)
-
 $(REVERSE_FRAMES:%.png=%.inc.c): %.inc.c : %.png
 	$(N64GRAPHICS) -Z $@ -g $< -s u8 -f ci8 -c rgba16 -p $(REVERSE_PALETTE)
 
@@ -37,3 +35,9 @@ $(REVERSE_FRAMES) $(REVERSE_PALETTE): $(REVERSE_EXPORT_SENTINEL) ;
 $(REVERSE_EXPORT_SENTINEL): assets/lakitu/reverse.json
 	$(ASSET_EXTRACT) $(BASEROM) $<
 	touch $@
+
+.PHONY: distclean_lakitu_reverse
+distclean_lakitu_reverse:
+	rm -rf $(REVERSE_DIR)
+
+distclean_assets: distclean_lakitu_reverse

--- a/assets/include/lakitu/secondlap.mk
+++ b/assets/include/lakitu/secondlap.mk
@@ -22,8 +22,6 @@ $(SECONDLAP_DIR)/gTextureLakituSecondLap16.png
 
 SECONDLAP_EXPORT_SENTINEL := $(SECONDLAP_DIR)/.export
 
-ASSET_DIRECTORIES += $(SECONDLAP_DIR)
-
 $(SECONDLAP_FRAMES:%.png=%.inc.c): %.inc.c : %.png
 	$(N64GRAPHICS) -Z $@ -g $< -s u8 -f ci8 -c rgba16 -p $(SECONDLAP_PALETTE)
 
@@ -37,3 +35,9 @@ $(SECONDLAP_FRAMES) $(SECONDLAP_PALETTE): $(SECONDLAP_EXPORT_SENTINEL) ;
 $(SECONDLAP_EXPORT_SENTINEL): assets/lakitu/secondlap.json
 	$(ASSET_EXTRACT) $(BASEROM) $<
 	touch $@
+
+.PHONY: distclean_lakitu_secondlap
+distclean_lakitu_secondlap:
+	rm -rf $(SECONDLAP_DIR)
+
+distclean_assets: distclean_lakitu_secondlap

--- a/assets/include/minimap_icons.mk
+++ b/assets/include/minimap_icons.mk
@@ -14,8 +14,6 @@ $(MINIMAP_ICONS_DIR)/gTextureMiniMapProgressDot.png
 
 MINIMAP_ICONS_EXPORT_SENTINEL := $(MINIMAP_ICONS_DIR)/.export
 
-ASSET_DIRECTORIES += $(MINIMAP_ICONS_DIR)
-
 $(BUILD_DIR)/src/common_textures.inc.o: $(MINIMAP_ICONS_PNG:%.png=%.inc.c)
 
 $(MINIMAP_ICONS_PNG:%.png=%.inc.c): %.inc.c : %.png
@@ -26,3 +24,9 @@ $(MINIMAP_ICONS_PNG): $(MINIMAP_ICONS_EXPORT_SENTINEL) ;
 $(MINIMAP_ICONS_EXPORT_SENTINEL): $(ASSET_DIR)/minimap_icons.json
 	$(ASSET_EXTRACT) $(BASEROM) $<
 	touch $@
+
+.PHONY: distclean_minimap_icons
+distclean_minimap_icons:
+	rm -rf $(MINIMAP_ICONS_DIR)
+
+distclean_assets: distclean_minimap_icons

--- a/assets/include/onomatopoeia.mk
+++ b/assets/include/onomatopoeia.mk
@@ -14,8 +14,6 @@ $(ONOMATOPOEIA_DIR)/gTextureBalloon2.png
 
 ONOMATOPOEIA_EXPORT_SENTINEL := $(ONOMATOPOEIA_DIR)/.export
 
-ASSET_DIRECTORIES += $(ONOMATOPOEIA_DIR)
-
 $(BUILD_DIR)/$(DATA_DIR)/other_textures.o: $(ONOMATOPOEIA_PNG:%.png=%.mio0)
 
 $(ONOMATOPOEIA_PNG:%.png=%.mio0): %.mio0 : %.bin
@@ -32,3 +30,9 @@ $(ONOMATOPOEIA_PNG) $(ONOMATOPOEIA_PALETTE): $(ONOMATOPOEIA_EXPORT_SENTINEL) ;
 $(ONOMATOPOEIA_EXPORT_SENTINEL): $(ASSET_DIR)/onomatopoeia.json
 	$(ASSET_EXTRACT) $(BASEROM) $<
 	touch $@
+
+.PHONY: distclean_onomatopoeia
+distclean_onomatopoeia:
+	rm -rf $(ONOMATOPOEIA_DIR)
+
+distclean_assets: distclean_onomatopoeia


### PR DESCRIPTION
This allows each asset group to define its own cleanup procedure
 while also providing a way to cleanup specific asset groups.