### PR TITLE
Fixes the error "iconv: invalid option -- o" by redirecting stdout to the desired file. 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -564,7 +564,7 @@ COURSE_DATA_TARGETS := $(foreach dir,$(COURSE_DIRS),$(BUILD_DIR)/$(dir)/course_d
 
 $(BUILD_DIR)/%.jp.c: %.c
 	$(call print,Encoding:,$<,$@)
-	iconv -t EUC-JP -f UTF-8 $< > $@
+	iconv -t EUC-JP -f UTF-8 $< -o $@
 
 $(BUILD_DIR)/%.o: %.c
 	$(call print,Compiling:,$<,$@)

--- a/Makefile
+++ b/Makefile
@@ -564,17 +564,8 @@ COURSE_DATA_TARGETS := $(foreach dir,$(COURSE_DIRS),$(BUILD_DIR)/$(dir)/course_d
 #==============================================================================#
 $(BUILD_DIR)/%.jp.c: %.c
 	$(call print,Encoding:,$<,$@)
-<<<<<<< HEAD
-  ifeq ($(UNAME_S), Darwin)
-	  iconv -t EUC-JP -f UTF-8 $< > $@
-  endif
-  ifeq ($(UNAME_S), Linux)
-    iconv -t EUC-JP -f UTF-8 $< -o $@
-  endif
-=======
 	iconv -t EUC-JP -f UTF-8 $< > $@
 
->>>>>>> parent of 2ec090f80 (Revert "Fixes the error "iconv: invalid option -- o" by redirecting stdout to the desired file. Fixes build errors on macos")
 $(BUILD_DIR)/%.o: %.c
 	$(call print,Compiling:,$<,$@)
 	$(V)$(CC_CHECK) $(CC_CHECK_CFLAGS) -MMD -MP -MT $@ -MF $(BUILD_DIR)/$*.d $<

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ default: all
 
 # Preprocessor definitions
 DEFINES :=
+UNAME_S := $(shell uname -s)
 
 #==============================================================================#
 # Build Options                                                                #
@@ -561,11 +562,14 @@ COURSE_DATA_TARGETS := $(foreach dir,$(COURSE_DIRS),$(BUILD_DIR)/$(dir)/course_d
 #==============================================================================#
 # Source Code Generation                                                       #
 #==============================================================================#
-
 $(BUILD_DIR)/%.jp.c: %.c
 	$(call print,Encoding:,$<,$@)
-	iconv -t EUC-JP -f UTF-8 $< -o $@
-
+  ifeq ($(UNAME_S), Darwin)
+	  iconv -t EUC-JP -f UTF-8 $< > $@
+  endif
+  ifeq ($(UNAME_S), Darwin)
+    iconv -t EUC-JP -f UTF-8 $< -o $@
+  endif
 $(BUILD_DIR)/%.o: %.c
 	$(call print,Compiling:,$<,$@)
 	$(V)$(CC_CHECK) $(CC_CHECK_CFLAGS) -MMD -MP -MT $@ -MF $(BUILD_DIR)/$*.d $<

--- a/Makefile
+++ b/Makefile
@@ -567,7 +567,7 @@ $(BUILD_DIR)/%.jp.c: %.c
   ifeq ($(UNAME_S), Darwin)
 	  iconv -t EUC-JP -f UTF-8 $< > $@
   endif
-  ifeq ($(UNAME_S), Darwin)
+  ifeq ($(UNAME_S), Linux)
     iconv -t EUC-JP -f UTF-8 $< -o $@
   endif
 $(BUILD_DIR)/%.o: %.c

--- a/Makefile
+++ b/Makefile
@@ -564,12 +564,17 @@ COURSE_DATA_TARGETS := $(foreach dir,$(COURSE_DIRS),$(BUILD_DIR)/$(dir)/course_d
 #==============================================================================#
 $(BUILD_DIR)/%.jp.c: %.c
 	$(call print,Encoding:,$<,$@)
+<<<<<<< HEAD
   ifeq ($(UNAME_S), Darwin)
 	  iconv -t EUC-JP -f UTF-8 $< > $@
   endif
   ifeq ($(UNAME_S), Linux)
     iconv -t EUC-JP -f UTF-8 $< -o $@
   endif
+=======
+	iconv -t EUC-JP -f UTF-8 $< > $@
+
+>>>>>>> parent of 2ec090f80 (Revert "Fixes the error "iconv: invalid option -- o" by redirecting stdout to the desired file. Fixes build errors on macos")
 $(BUILD_DIR)/%.o: %.c
 	$(call print,Compiling:,$<,$@)
 	$(V)$(CC_CHECK) $(CC_CHECK_CFLAGS) -MMD -MP -MT $@ -MF $(BUILD_DIR)/$*.d $<

--- a/Makefile
+++ b/Makefile
@@ -564,7 +564,7 @@ COURSE_DATA_TARGETS := $(foreach dir,$(COURSE_DIRS),$(BUILD_DIR)/$(dir)/course_d
 
 $(BUILD_DIR)/%.jp.c: %.c
 	$(call print,Encoding:,$<,$@)
-	iconv -t EUC-JP -f UTF-8 $< -o $@
+	iconv -t EUC-JP -f UTF-8 $< > $@
 
 $(BUILD_DIR)/%.o: %.c
 	$(call print,Compiling:,$<,$@)


### PR DESCRIPTION
Was having issues building on MacOS (presumably due to some weird Apple specific version of iconv) but changing this line allowed the build to complete successfully