### PR TITLE
Fix color text array and function

### DIFF
--- a/src/code_80091750.c
+++ b/src/code_80091750.c
@@ -934,11 +934,12 @@ s32 D_800E84A0[] = {
 };
 
 Vtx* D_800E84C0[] = {
-    &D_02007BB8[0],
-    &D_02007BB8[18],
-    &D_02007BB8[36],
+    D_02007BB8,
+    D_02007CD8,
+    D_02007DF8,
 };
 
+#ifndef AVOID_UB
 Gfx* D_800E84CC[] = {
     D_02007838, D_02007858, D_02007878, D_02007898, D_020078B8, D_020078D8, D_020078F8, D_02007918,
 };
@@ -950,6 +951,7 @@ Gfx* D_800E84EC[] = {
 Gfx* D_800E850C[] = {
     D_02007A38, D_02007A58, D_02007A78, D_02007A98, D_02007AB8, D_02007AD8, D_02007AF8, D_02007B18,
 };
+#endif
 
 s8 D_800E852C = 1;
 
@@ -2512,14 +2514,11 @@ Gfx* func_800959F8(Gfx* displayListHead, Vtx* arg1) {
     } else {
         index = ((gTextColor * 2) + ((s32) gGlobalTimer % 2)) - 4;
     }
+
 #ifdef AVOID_UB
-    if (arg1 == D_02007BB8) {
-        gSPDisplayList(displayListHead++, D_800E84CC[index]);
-    } else if (arg1 == &D_02007BB8[18]) {
-        gSPDisplayList(displayListHead++, D_800E84EC[index]);
-    } else if (arg1 == &D_02007BB8[36]) {
-        gSPDisplayList(displayListHead++, D_800E850C[index]);
-    }
+    gSPVertex(displayListHead++, arg1, 2, 0);
+    gSPVertex(displayListHead++, &arg1[(index + 1) * 2], 2, 2);
+    gSPDisplayList(displayListHead++, common_rectangle_display);
 #else
     if (arg1 == D_02007BB8) {
         gSPDisplayList(displayListHead++, D_800E84CC[index]);
@@ -2633,16 +2632,16 @@ func_80095BD0_label2:
                           G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMASK, G_TX_NOMASK, G_TX_NOLOD, G_TX_NOLOD);
     switch (arg4) {
         default:
-            var_a1 = &D_02007BB8[18];
+            var_a1 = D_02007CD8;
             break;
         case 16:
-            var_a1 = &D_02007BB8[18];
+            var_a1 = D_02007CD8;
             break;
         case 26:
             var_a1 = D_02007BB8;
             break;
         case 30:
-            var_a1 = &D_02007BB8[36];
+            var_a1 = D_02007DF8;
             break;
     }
 

--- a/src/code_80091750.c
+++ b/src/code_80091750.c
@@ -2514,7 +2514,6 @@ Gfx* func_800959F8(Gfx* displayListHead, Vtx* arg1) {
     } else {
         index = ((gTextColor * 2) + ((s32) gGlobalTimer % 2)) - 4;
     }
-
 #ifdef AVOID_UB
     gSPVertex(displayListHead++, arg1, 2, 0);
     gSPVertex(displayListHead++, &arg1[(index + 1) * 2], 2, 2);

--- a/src/data/data_segment2.c
+++ b/src/data/data_segment2.c
@@ -101,6 +101,7 @@ Gfx D_02007818[] = {
     gsSPEndDisplayList(),
 };
 
+#ifndef AVOID_UB
 Gfx D_02007838[] = {
     gsSPVertex(D_02007BB8, 2, 0),
     gsSPVertex(&D_02007BB8[2], 2, 2),
@@ -158,132 +159,135 @@ Gfx D_02007918[] = {
 };
 
 Gfx D_02007938[] = {
-    gsSPVertex(&D_02007BB8[18], 2, 0),
-    gsSPVertex(&D_02007BB8[20], 2, 2),
+    gsSPVertex(D_02007CD8, 2, 0),
+    gsSPVertex(&D_02007CD8[2], 2, 2),
     gsSPDisplayList(common_rectangle_display),
     gsSPEndDisplayList(),
 };
 
 Gfx D_02007958[] = {
-    gsSPVertex(&D_02007BB8[18], 2, 0),
-    gsSPVertex(&D_02007BB8[22], 2, 2),
+    gsSPVertex(D_02007CD8, 2, 0),
+    gsSPVertex(&D_02007CD8[4], 2, 2),
     gsSPDisplayList(common_rectangle_display),
     gsSPEndDisplayList(),
 };
 
 Gfx D_02007978[] = {
-    gsSPVertex(&D_02007BB8[18], 2, 0),
-    gsSPVertex(&D_02007BB8[24], 2, 2),
+    gsSPVertex(D_02007CD8, 2, 0),
+    gsSPVertex(&D_02007CD8[6], 2, 2),
     gsSPDisplayList(common_rectangle_display),
     gsSPEndDisplayList(),
 };
 
 Gfx D_02007998[] = {
-    gsSPVertex(&D_02007BB8[18], 2, 0),
-    gsSPVertex(&D_02007BB8[26], 2, 2),
+    gsSPVertex(D_02007CD8, 2, 0),
+    gsSPVertex(&D_02007CD8[8], 2, 2),
     gsSPDisplayList(common_rectangle_display),
     gsSPEndDisplayList(),
 };
 
 Gfx D_020079B8[] = {
-    gsSPVertex(&D_02007BB8[18], 2, 0),
-    gsSPVertex(&D_02007BB8[28], 2, 2),
+    gsSPVertex(D_02007CD8, 2, 0),
+    gsSPVertex(&D_02007CD8[10], 2, 2),
     gsSPDisplayList(common_rectangle_display),
     gsSPEndDisplayList(),
 };
 
 Gfx D_020079D8[] = {
-    gsSPVertex(&D_02007BB8[18], 2, 0),
-    gsSPVertex(&D_02007BB8[30], 2, 2),
+    gsSPVertex(D_02007CD8, 2, 0),
+    gsSPVertex(&D_02007CD8[12], 2, 2),
     gsSPDisplayList(common_rectangle_display),
     gsSPEndDisplayList(),
 };
 
 Gfx D_020079F8[] = {
-    gsSPVertex(&D_02007BB8[18], 2, 0),
-    gsSPVertex(&D_02007BB8[32], 2, 2),
+    gsSPVertex(D_02007CD8, 2, 0),
+    gsSPVertex(&D_02007CD8[14], 2, 2),
     gsSPDisplayList(common_rectangle_display),
     gsSPEndDisplayList(),
 };
 
 Gfx D_02007A18[] = {
-    gsSPVertex(&D_02007BB8[18], 2, 0),
-    gsSPVertex(&D_02007BB8[34], 2, 2),
+    gsSPVertex(D_02007CD8, 2, 0),
+    gsSPVertex(&D_02007CD8[16], 2, 2),
     gsSPDisplayList(common_rectangle_display),
     gsSPEndDisplayList(),
 };
 
 Gfx D_02007A38[] = {
-    gsSPVertex(&D_02007BB8[36], 2, 0),
-    gsSPVertex(&D_02007BB8[38], 2, 2),
+    gsSPVertex(D_02007DF8, 2, 0),
+    gsSPVertex(&D_02007DF8[2], 2, 2),
     gsSPDisplayList(common_rectangle_display),
     gsSPEndDisplayList(),
 };
 
 Gfx D_02007A58[] = {
-    gsSPVertex(&D_02007BB8[36], 2, 0),
-    gsSPVertex(&D_02007BB8[40], 2, 2),
+    gsSPVertex(D_02007DF8, 2, 0),
+    gsSPVertex(&D_02007DF8[4], 2, 2),
     gsSPDisplayList(common_rectangle_display),
     gsSPEndDisplayList(),
 };
 
 Gfx D_02007A78[] = {
-    gsSPVertex(&D_02007BB8[36], 2, 0),
-    gsSPVertex(&D_02007BB8[42], 2, 2),
+    gsSPVertex(D_02007DF8, 2, 0),
+    gsSPVertex(&D_02007DF8[6], 2, 2),
     gsSPDisplayList(common_rectangle_display),
     gsSPEndDisplayList(),
 };
 
 Gfx D_02007A98[] = {
-    gsSPVertex(&D_02007BB8[36], 2, 0),
-    gsSPVertex(&D_02007BB8[44], 2, 2),
+    gsSPVertex(D_02007DF8, 2, 0),
+    gsSPVertex(&D_02007DF8[8], 2, 2),
     gsSPDisplayList(common_rectangle_display),
     gsSPEndDisplayList(),
 };
 
 Gfx D_02007AB8[] = {
-    gsSPVertex(&D_02007BB8[36], 2, 0),
-    gsSPVertex(&D_02007BB8[46], 2, 2),
+    gsSPVertex(D_02007DF8, 2, 0),
+    gsSPVertex(&D_02007DF8[10], 2, 2),
     gsSPDisplayList(common_rectangle_display),
     gsSPEndDisplayList(),
 };
 
 Gfx D_02007AD8[] = {
-    gsSPVertex(&D_02007BB8[36], 2, 0),
-    gsSPVertex(&D_02007BB8[48], 2, 2),
+    gsSPVertex(D_02007DF8, 2, 0),
+    gsSPVertex(&D_02007DF8[12], 2, 2),
     gsSPDisplayList(common_rectangle_display),
     gsSPEndDisplayList(),
 };
 
 Gfx D_02007AF8[] = {
-    gsSPVertex(&D_02007BB8[36], 2, 0),
-    gsSPVertex(&D_02007BB8[50], 2, 2),
+    gsSPVertex(D_02007DF8, 2, 0),
+    gsSPVertex(&D_02007DF8[14], 2, 2),
     gsSPDisplayList(common_rectangle_display),
     gsSPEndDisplayList(),
 };
 
 Gfx D_02007B18[] = {
-    gsSPVertex(&D_02007BB8[36], 2, 0),
-    gsSPVertex(&D_02007BB8[52], 2, 2),
+    gsSPVertex(D_02007DF8, 2, 0),
+    gsSPVertex(&D_02007DF8[16], 2, 2),
     gsSPDisplayList(common_rectangle_display),
     gsSPEndDisplayList(),
 };
+#endif
 
 UNUSED Vtx D_02007B38[] = {
     { { { 0, 0, 0 }, 0, { 0, 0 }, { 0xff, 0xff, 0xff, 0xff } } },
     { { { 16, 0, 0 }, 0, { 0, 0 }, { 0xff, 0xff, 0xff, 0xff } } },
     { { { 16, 16, 0 }, 0, { 0, 0 }, { 0xff, 0xff, 0xff, 0xff } } },
     { { { 0, 16, 0 }, 0, { 0, 0 }, { 0xff, 0xff, 0xff, 0xff } } },
+};
+
+UNUSED Vtx D_02007B78[] = {
     { { { 0, -8, 0 }, 0, { 0, 0 }, { 0xff, 0xff, 0xff, 0xff } } },
     { { { 8, -8, 0 }, 0, { 448, 0 }, { 0xff, 0xff, 0xff, 0xff } } },
     { { { 8, 0, 0 }, 0, { 448, 448 }, { 0xff, 0x00, 0x00, 0xff } } },
     { { { 0, 0, 0 }, 0, { 0, 448 }, { 0xff, 0x00, 0x00, 0xff } } },
 };
 
-#ifdef AVOID_UB
 Vtx D_02007BB8[] = {
-    { { { 0, 65520, 0 }, 0, { 0, 0 }, { 0xff, 0xff, 0xff, 0xff } } },
-    { { { 26, 65520, 0 }, 0, { 1600, 0 }, { 0xff, 0xff, 0xff, 0xff } } },
+    { { { 0, -16, 0 }, 0, { 0, 0 }, { 0xff, 0xff, 0xff, 0xff } } },
+    { { { 26, -16, 0 }, 0, { 1600, 0 }, { 0xff, 0xff, 0xff, 0xff } } },
     { { { 26, 0, 0 }, 0, { 1600, 960 }, { 0x00, 0x00, 0xff, 0xff } } },
     { { { 0, 0, 0 }, 0, { 0, 960 }, { 0x00, 0x00, 0xff, 0xff } } },
     { { { 26, 0, 0 }, 0, { 1600, 960 }, { 0x00, 0xff, 0x00, 0xff } } },
@@ -298,181 +302,51 @@ Vtx D_02007BB8[] = {
     { { { 0, 0, 0 }, 0, { 0, 960 }, { 0xff, 0x00, 0x00, 0xff } } },
     { { { 26, 0, 0 }, 0, { 1600, 960 }, { 0xff, 0x00, 0x00, 0xff } } },
     { { { 0, 0, 0 }, 0, { 0, 960 }, { 0xff, 0x00, 0x00, 0xff } } },
-    { { { 26, 0, 0 }, 0, { 1600, 960 }, { 0xff, 0x00, 0x00, 0xff } } },
-    { { { 0, 0, 0 }, 0, { 0, 960 }, { 0xff, 0x00, 0x00, 0xff } } },
-    { { { 0, 65520, 0 }, 0, { 0, 0 }, { 0xff, 0xff, 0xff, 0xff } } },
-    { { { 16, 65520, 0 }, 0, { 960, 0 }, { 0xff, 0xff, 0xff, 0xff } } },
-    { { { 16, 0, 0 }, 0, { 960, 960 }, { 0x00, 0x00, 0xff, 0xff } } },
-    { { { 0, 0, 0 }, 0, { 0, 960 }, { 0x00, 0x00, 0xff, 0xff } } },
-    { { { 16, 0, 0 }, 0, { 960, 960 }, { 0x00, 0xff, 0x00, 0xff } } },
-    { { { 0, 0, 0 }, 0, { 0, 960 }, { 0x00, 0xff, 0x00, 0xff } } },
-    { { { 16, 0, 0 }, 0, { 960, 960 }, { 0xff, 0x00, 0x00, 0xff } } },
-    { { { 0, 0, 0 }, 0, { 0, 960 }, { 0xff, 0x00, 0x00, 0xff } } },
-    { { { 16, 0, 0 }, 0, { 960, 960 }, { 0xff, 0xff, 0x00, 0xff } } },
-    { { { 0, 0, 0 }, 0, { 0, 960 }, { 0xff, 0xff, 0x00, 0xff } } },
-    { { { 16, 0, 0 }, 0, { 960, 960 }, { 0xff, 0x00, 0x00, 0xff } } },
-    { { { 0, 0, 0 }, 0, { 0, 960 }, { 0xff, 0x00, 0x00, 0xff } } },
-    { { { 16, 0, 0 }, 0, { 960, 960 }, { 0xff, 0x00, 0x00, 0xff } } },
-    { { { 0, 0, 0 }, 0, { 0, 960 }, { 0xff, 0x00, 0x00, 0xff } } },
-    { { { 16, 0, 0 }, 0, { 960, 960 }, { 0xff, 0x00, 0x00, 0xff } } },
-    { { { 0, 0, 0 }, 0, { 0, 960 }, { 0xff, 0x00, 0x00, 0xff } } },
-    { { { 16, 0, 0 }, 0, { 960, 960 }, { 0xff, 0x00, 0x00, 0xff } } },
-    { { { 0, 0, 0 }, 0, { 0, 960 }, { 0xff, 0x00, 0x00, 0xff } } },
-    { { { 0, 65504, 0 }, 0, { 0, 0 }, { 0xff, 0xff, 0xff, 0xff } } },
-    { { { 30, 65504, 0 }, 0, { 1856, 0 }, { 0xff, 0xff, 0xff, 0xff } } },
-    { { { 30, 0, 0 }, 0, { 1856, 1984 }, { 0x00, 0x00, 0xff, 0xff } } },
-    { { { 0, 0, 0 }, 0, { 0, 1984 }, { 0x00, 0x00, 0xff, 0xff } } },
-    { { { 30, 0, 0 }, 0, { 1856, 1984 }, { 0x00, 0xff, 0x00, 0xff } } },
-    { { { 0, 0, 0 }, 0, { 0, 1984 }, { 0x00, 0xff, 0x00, 0xff } } },
-    { { { 30, 0, 0 }, 0, { 1856, 1984 }, { 0xff, 0x00, 0x00, 0xff } } },
-    { { { 0, 0, 0 }, 0, { 0, 1984 }, { 0xff, 0x00, 0x00, 0xff } } },
-    { { { 30, 0, 0 }, 0, { 1856, 1984 }, { 0xff, 0xff, 0x00, 0xff } } },
-    { { { 0, 0, 0 }, 0, { 0, 1984 }, { 0xff, 0xff, 0x00, 0xff } } },
-    { { { 30, 0, 0 }, 0, { 1856, 1984 }, { 0xff, 0x00, 0x00, 0xff } } },
-    { { { 0, 0, 0 }, 0, { 0, 1984 }, { 0xff, 0x00, 0x00, 0xff } } },
-    { { { 30, 0, 0 }, 0, { 1856, 1984 }, { 0xff, 0x00, 0x00, 0xff } } },
-    { { { 0, 0, 0 }, 0, { 0, 1984 }, { 0xff, 0x00, 0x00, 0xff } } },
-    { { { 30, 0, 0 }, 0, { 1856, 1984 }, { 0xff, 0x00, 0x00, 0xff } } },
-    { { { 0, 0, 0 }, 0, { 0, 1984 }, { 0xff, 0x00, 0x00, 0xff } } },
-    { { { 30, 0, 0 }, 0, { 1856, 1984 }, { 0xff, 0x00, 0x00, 0xff } } },
-    { { { 0, 0, 0 }, 0, { 0, 1984 }, { 0xff, 0x00, 0x00, 0xff } } },
-};
-#else
-Vtx D_02007BB8[] = {
-    { { { 0, 65520, 0 }, 0, { 0, 0 }, { 0xff, 0xff, 0xff, 0xff } } },
-    { { { 26, 65520, 0 }, 0, { 1600, 0 }, { 0xff, 0xff, 0xff, 0xff } } },
-};
-
-Vtx D_02007BD8[] = {
-    { { { 26, 0, 0 }, 0, { 1600, 960 }, { 0x00, 0x00, 0xff, 0xff } } },
-    { { { 0, 0, 0 }, 0, { 0, 960 }, { 0x00, 0x00, 0xff, 0xff } } },
-};
-
-Vtx D_02007BF8[] = {
-    { { { 26, 0, 0 }, 0, { 1600, 960 }, { 0x00, 0xff, 0x00, 0xff } } },
-    { { { 0, 0, 0 }, 0, { 0, 960 }, { 0x00, 0xff, 0x00, 0xff } } },
-};
-
-Vtx D_02007C18[] = {
-    { { { 26, 0, 0 }, 0, { 1600, 960 }, { 0xff, 0x00, 0x00, 0xff } } },
-    { { { 0, 0, 0 }, 0, { 0, 960 }, { 0xff, 0x00, 0x00, 0xff } } },
-};
-
-Vtx D_02007C38[] = {
-    { { { 26, 0, 0 }, 0, { 1600, 960 }, { 0xff, 0xff, 0x00, 0xff } } },
-    { { { 0, 0, 0 }, 0, { 0, 960 }, { 0xff, 0xff, 0x00, 0xff } } },
-};
-
-Vtx D_02007C58[] = {
-    { { { 26, 0, 0 }, 0, { 1600, 960 }, { 0xff, 0x00, 0x00, 0xff } } },
-    { { { 0, 0, 0 }, 0, { 0, 960 }, { 0xff, 0x00, 0x00, 0xff } } },
-};
-
-Vtx D_02007C78[] = {
-    { { { 26, 0, 0 }, 0, { 1600, 960 }, { 0xff, 0x00, 0x00, 0xff } } },
-    { { { 0, 0, 0 }, 0, { 0, 960 }, { 0xff, 0x00, 0x00, 0xff } } },
-};
-
-Vtx D_02007C98[] = {
-    { { { 26, 0, 0 }, 0, { 1600, 960 }, { 0xff, 0x00, 0x00, 0xff } } },
-    { { { 0, 0, 0 }, 0, { 0, 960 }, { 0xff, 0x00, 0x00, 0xff } } },
-};
-
-Vtx D_02007CB8[] = {
     { { { 26, 0, 0 }, 0, { 1600, 960 }, { 0xff, 0x00, 0x00, 0xff } } },
     { { { 0, 0, 0 }, 0, { 0, 960 }, { 0xff, 0x00, 0x00, 0xff } } },
 };
 
 Vtx D_02007CD8[] = {
-    { { { 0, 65520, 0 }, 0, { 0, 0 }, { 0xff, 0xff, 0xff, 0xff } } },
-    { { { 16, 65520, 0 }, 0, { 960, 0 }, { 0xff, 0xff, 0xff, 0xff } } },
-};
-
-Vtx D_02007CF8[] = {
+    { { { 0, -16, 0 }, 0, { 0, 0 }, { 0xff, 0xff, 0xff, 0xff } } },
+    { { { 16, -16, 0 }, 0, { 960, 0 }, { 0xff, 0xff, 0xff, 0xff } } },
     { { { 16, 0, 0 }, 0, { 960, 960 }, { 0x00, 0x00, 0xff, 0xff } } },
     { { { 0, 0, 0 }, 0, { 0, 960 }, { 0x00, 0x00, 0xff, 0xff } } },
-};
-
-Vtx D_02007D18[] = {
     { { { 16, 0, 0 }, 0, { 960, 960 }, { 0x00, 0xff, 0x00, 0xff } } },
     { { { 0, 0, 0 }, 0, { 0, 960 }, { 0x00, 0xff, 0x00, 0xff } } },
-};
-
-Vtx D_02007D38[] = {
     { { { 16, 0, 0 }, 0, { 960, 960 }, { 0xff, 0x00, 0x00, 0xff } } },
     { { { 0, 0, 0 }, 0, { 0, 960 }, { 0xff, 0x00, 0x00, 0xff } } },
-};
-
-Vtx D_02007D58[] = {
     { { { 16, 0, 0 }, 0, { 960, 960 }, { 0xff, 0xff, 0x00, 0xff } } },
     { { { 0, 0, 0 }, 0, { 0, 960 }, { 0xff, 0xff, 0x00, 0xff } } },
-};
-
-Vtx D_02007D78[] = {
     { { { 16, 0, 0 }, 0, { 960, 960 }, { 0xff, 0x00, 0x00, 0xff } } },
     { { { 0, 0, 0 }, 0, { 0, 960 }, { 0xff, 0x00, 0x00, 0xff } } },
-};
-
-Vtx D_02007D98[] = {
     { { { 16, 0, 0 }, 0, { 960, 960 }, { 0xff, 0x00, 0x00, 0xff } } },
     { { { 0, 0, 0 }, 0, { 0, 960 }, { 0xff, 0x00, 0x00, 0xff } } },
-};
-
-Vtx D_02007DB8[] = {
     { { { 16, 0, 0 }, 0, { 960, 960 }, { 0xff, 0x00, 0x00, 0xff } } },
     { { { 0, 0, 0 }, 0, { 0, 960 }, { 0xff, 0x00, 0x00, 0xff } } },
-};
-
-Vtx D_02007DD8[] = {
     { { { 16, 0, 0 }, 0, { 960, 960 }, { 0xff, 0x00, 0x00, 0xff } } },
     { { { 0, 0, 0 }, 0, { 0, 960 }, { 0xff, 0x00, 0x00, 0xff } } },
 };
 
 Vtx D_02007DF8[] = {
-    { { { 0, 65504, 0 }, 0, { 0, 0 }, { 0xff, 0xff, 0xff, 0xff } } },
-    { { { 30, 65504, 0 }, 0, { 1856, 0 }, { 0xff, 0xff, 0xff, 0xff } } },
-};
-
-Vtx D_02007E18[] = {
+    { { { 0, -32, 0 }, 0, { 0, 0 }, { 0xff, 0xff, 0xff, 0xff } } },
+    { { { 30, -32, 0 }, 0, { 1856, 0 }, { 0xff, 0xff, 0xff, 0xff } } },
     { { { 30, 0, 0 }, 0, { 1856, 1984 }, { 0x00, 0x00, 0xff, 0xff } } },
     { { { 0, 0, 0 }, 0, { 0, 1984 }, { 0x00, 0x00, 0xff, 0xff } } },
-};
-
-Vtx D_02007E38[] = {
     { { { 30, 0, 0 }, 0, { 1856, 1984 }, { 0x00, 0xff, 0x00, 0xff } } },
     { { { 0, 0, 0 }, 0, { 0, 1984 }, { 0x00, 0xff, 0x00, 0xff } } },
-};
-
-Vtx D_02007E58[] = {
     { { { 30, 0, 0 }, 0, { 1856, 1984 }, { 0xff, 0x00, 0x00, 0xff } } },
     { { { 0, 0, 0 }, 0, { 0, 1984 }, { 0xff, 0x00, 0x00, 0xff } } },
-};
-
-Vtx D_02007E78[] = {
     { { { 30, 0, 0 }, 0, { 1856, 1984 }, { 0xff, 0xff, 0x00, 0xff } } },
     { { { 0, 0, 0 }, 0, { 0, 1984 }, { 0xff, 0xff, 0x00, 0xff } } },
-};
-
-Vtx D_02007E98[] = {
+    { { { 30, 0, 0 }, 0, { 1856, 1984 }, { 0xff, 0x00, 0x00, 0xff } } },
+    { { { 0, 0, 0 }, 0, { 0, 1984 }, { 0xff, 0x00, 0x00, 0xff } } },
+    { { { 30, 0, 0 }, 0, { 1856, 1984 }, { 0xff, 0x00, 0x00, 0xff } } },
+    { { { 0, 0, 0 }, 0, { 0, 1984 }, { 0xff, 0x00, 0x00, 0xff } } },
+    { { { 30, 0, 0 }, 0, { 1856, 1984 }, { 0xff, 0x00, 0x00, 0xff } } },
+    { { { 0, 0, 0 }, 0, { 0, 1984 }, { 0xff, 0x00, 0x00, 0xff } } },
     { { { 30, 0, 0 }, 0, { 1856, 1984 }, { 0xff, 0x00, 0x00, 0xff } } },
     { { { 0, 0, 0 }, 0, { 0, 1984 }, { 0xff, 0x00, 0x00, 0xff } } },
 };
-
-Vtx D_02007EB8[] = {
-    { { { 30, 0, 0 }, 0, { 1856, 1984 }, { 0xff, 0x00, 0x00, 0xff } } },
-    { { { 0, 0, 0 }, 0, { 0, 1984 }, { 0xff, 0x00, 0x00, 0xff } } },
-};
-
-Vtx D_02007ED8[] = {
-    { { { 30, 0, 0 }, 0, { 1856, 1984 }, { 0xff, 0x00, 0x00, 0xff } } },
-    { { { 0, 0, 0 }, 0, { 0, 1984 }, { 0xff, 0x00, 0x00, 0xff } } },
-};
-
-Vtx D_02007EF8[] = {
-    { { { 30, 0, 0 }, 0, { 1856, 1984 }, { 0xff, 0x00, 0x00, 0xff } } },
-    { { { 0, 0, 0 }, 0, { 0, 1984 }, { 0xff, 0x00, 0x00, 0xff } } },
-};
-#endif
 
 Gfx D_02007F18[] = {
     gsDPPipeSync(),

--- a/src/data_segment2.h
+++ b/src/data_segment2.h
@@ -17,6 +17,7 @@ extern Gfx D_020077A8[];
 extern Gfx D_020077D8[];
 extern Gfx D_020077F8[];
 extern Gfx D_02007818[];
+#ifndef AVOID_UB
 extern Gfx D_02007838[];
 extern Gfx D_02007858[];
 extern Gfx D_02007878[];
@@ -41,6 +42,7 @@ extern Gfx D_02007AB8[];
 extern Gfx D_02007AD8[];
 extern Gfx D_02007AF8[];
 extern Gfx D_02007B18[];
+#endif
 extern Gfx D_02007F18[];
 extern Gfx D_02007F48[];
 extern Gfx D_02007F60[];

--- a/src/data_segment2.h
+++ b/src/data_segment2.h
@@ -51,33 +51,7 @@ extern Gfx D_02008058[];
 extern Gfx common_rectangle_display[];
 
 extern Vtx D_02007BB8[];
-#ifndef AVOID_UB
-extern Vtx D_02007BD8[];
-extern Vtx D_02007BF8[];
-extern Vtx D_02007C18[];
-extern Vtx D_02007C38[];
-extern Vtx D_02007C58[];
-extern Vtx D_02007C78[];
-extern Vtx D_02007C98[];
-extern Vtx D_02007CB8[];
 extern Vtx D_02007CD8[];
-extern Vtx D_02007CF8[];
-extern Vtx D_02007D18[];
-extern Vtx D_02007D38[];
-extern Vtx D_02007D58[];
-extern Vtx D_02007D78[];
-extern Vtx D_02007D98[];
-extern Vtx D_02007DB8[];
-extern Vtx D_02007DD8[];
 extern Vtx D_02007DF8[];
-extern Vtx D_02007E18[];
-extern Vtx D_02007E38[];
-extern Vtx D_02007E58[];
-extern Vtx D_02007E78[];
-extern Vtx D_02007E98[];
-extern Vtx D_02007EB8[];
-extern Vtx D_02007ED8[];
-extern Vtx D_02007EF8[];
-#endif
 
 #endif


### PR DESCRIPTION
`func_800959F8` calls a DL array using a peculiar vtx argument check that renders a simple rectangle for the colored text and `func_80092290` manipulates the vtx colors to get the rainbow effects.

Since every DL follows the same pattern, enabling `AVOID_UB` fixes this by dynamically changing the vertex pointer, improving the usage of the vtx argument mentioned, while getting rid of the irrelevant arrays

Due to segments, vtx references on the DLs have different pointers (`&D_02007BB8[2]` as `0x02007CD8`). References for those pointers were fixed in code.

Fixes #572 