### PR TITLE
Player bitflag attributes

### DIFF
--- a/include/common_structs.h
+++ b/include/common_structs.h
@@ -293,7 +293,7 @@ typedef struct {
     /* 0x00B0 */ s16 unk_0B0;
     /* 0x00B2 */ s16 unk_0B2;
     /* 0x00B4 */ u16 unk_0B4;
-    /* 0x00B6 */ u16 kart_graphics;
+    /* 0x00B6 */ u16 kartGraphics;
     /* 0x00B8 */ f32 unk_0B8;
     /* 0x00BC */ u32 effects;
     /* 0x00C0 */ s16 unk_0C0;
@@ -301,7 +301,7 @@ typedef struct {
     /* 0x00C4 */ s16 slopeAccel;
     /* 0x00C6 */ s16 alpha;
     /* 0x00C8 */ s16 unk_0C8;
-    /* 0x00CA */ s16 lakitu_props;
+    /* 0x00CA */ s16 lakituProps;
     /* 0x00CC */ Vec4s unk_0CC;
     /* 0x00D4 */ Vec4s unk_0D4;
     /* 0x00DC */ s16 boostTimer;

--- a/include/common_structs.h
+++ b/include/common_structs.h
@@ -301,7 +301,7 @@ typedef struct {
     /* 0x00C4 */ s16 slopeAccel;
     /* 0x00C6 */ s16 alpha;
     /* 0x00C8 */ s16 unk_0C8;
-    /* 0x00CA */ s16 unk_0CA;
+    /* 0x00CA */ s16 lakitu_props;
     /* 0x00CC */ Vec4s unk_0CC;
     /* 0x00D4 */ Vec4s unk_0D4;
     /* 0x00DC */ s16 boostTimer;

--- a/include/common_structs.h
+++ b/include/common_structs.h
@@ -263,7 +263,7 @@ typedef struct {
     /* 0x0034 */ Vec3f velocity;
     /* 0x0040 */ s16 unk_040;
     /* 0x0042 */ s16 unk_042;
-    /* 0x0044 */ s16 unk_044;
+    /* 0x0044 */ s16 kartProps;
     /* 0x0046 */ u16 unk_046;
     /* 0x0048 */ Vec4s unk_048;
     /* 0x0050 */ Vec4s unk_050;

--- a/include/common_structs.h
+++ b/include/common_structs.h
@@ -293,7 +293,7 @@ typedef struct {
     /* 0x00B0 */ s16 unk_0B0;
     /* 0x00B2 */ s16 unk_0B2;
     /* 0x00B4 */ u16 unk_0B4;
-    /* 0x00B6 */ u16 unk_0B6;
+    /* 0x00B6 */ u16 kart_graphics;
     /* 0x00B8 */ f32 unk_0B8;
     /* 0x00BC */ u32 effects;
     /* 0x00C0 */ s16 unk_0C0;

--- a/include/common_structs.h
+++ b/include/common_structs.h
@@ -305,7 +305,7 @@ typedef struct {
     /* 0x00CC */ Vec4s unk_0CC;
     /* 0x00D4 */ Vec4s unk_0D4;
     /* 0x00DC */ s16 boostTimer;
-    /* 0x00DE */ u16 unk_0DE;
+    /* 0x00DE */ u16 oobProps;
     /* 0x00E0 */ s16 unk_0E0;
     /* 0x00E2 */ s16 unk_0E2;
     /* 0x00E4 */ f32 unk_0E4;

--- a/include/defines.h
+++ b/include/defines.h
@@ -327,10 +327,11 @@ enum PLACE { FIRST_PLACE, SECOND_PLACE, THIRD_PLACE, FOURTH_PLACE };
  * @brief Max representable time, 100 minutes measured in centiseconds
  */
 #define MAX_TIME 0x927C0
+#define DEGREES_CONVERSION_FACTOR 182
 
 #define UNK_044_BACK_UP 0x1
-#define UNK_044_RIGHT_TURN 0x2 // non-drifting
-#define UNK_044_LEFT_TURN 0x4 // non-drifting
+#define UNK_044_RIGHT_TURN 0x2 // non-drifting (more than 5 degrees)
+#define UNK_044_LEFT_TURN 0x4 // non-drifting (more than 5 degrees)
 #define UNK_044_MOVE_BACKWARDS 0x8 // includes lakitu
 #define UNK_044_LOSE_GP_RACE 0x10 // pointless, only unsets itself
 #define UNK_044_PRESS_A 0x20

--- a/include/defines.h
+++ b/include/defines.h
@@ -331,7 +331,7 @@ enum PLACE { FIRST_PLACE, SECOND_PLACE, THIRD_PLACE, FOURTH_PLACE };
 #define MAX_TIME 0x927C0
 #define DEGREES_CONVERSION_FACTOR 182
 
-// UNK_0DE
+// player->oobProps
 /* Deals with the lower out of bounds (OOB) plane on levels. Represented by fluids (water / lava)
   or nothing for Rainbow Road and Skyscraper. */
 #define UNDER_OOB_OR_FLUID_LEVEL 0x1 // Set while mostly under the plane. Does not necessarily trigger Lakitu on Koopa Troopa Beach.
@@ -357,8 +357,7 @@ player spins. Something  with avoding rollover of aniamation frame data? */
 #define BOING 0x800      // Boing! graphic (hopping)
 #define EXPLOSION 0x1000 // Big shock looking graphic when starting tumble
 
-
-
+// player->lakituProps
 #define LAKITU_RETRIEVAL 0x1 // While lakitu is grabbing you, but before the scene transition of being placed on the track
 #define HELD_BY_LAKITU   0x2
 #define LAKITU_FIZZLE    0x4 // Disintegration and reintegration effect when transitioning from retrieval to placement
@@ -370,6 +369,7 @@ player spins. Something  with avoding rollover of aniamation frame data? */
 #define LAKITU_LAVA   0x1000 // smoky effect when retrieved from lava
 #define LAKITU_WATER  0x2000 // dripping effect when retreived from water
 
+// player->kartGraphics
 #define BACK_UP               0x1
 #define RIGHT_TURN            0x2 // non-drifting (more than 5 degrees)
 #define LEFT_TURN             0x4 // non-drifting (more than 5 degrees)

--- a/include/defines.h
+++ b/include/defines.h
@@ -350,12 +350,12 @@ appear to the specified player */
 player spins. Something  with avoding rollover of aniamation frame data? */
 #define SIDE_OF_KART 0x8 // Seems to be whether you are in a rectangle shooting out from both sides of target player
 
-#define UNK_0B6_WHISTLE 0x20 // Whistle spinout save graphic
-#define UNK_0B6_CRASH 0x40 //Crash! graphic (vertical tumble)
-#define UNK_0B6_WHIRRR 0x80 //Whirrr! graphic (spinning out)
-#define UNK_0B6_POOMP 0x100 //Poomp! graphic (landing from a height)
-#define UNK_0B6_BOING 0x800 //Boing! graphic (hopping)
-#define UNK_0B6_EXPLOSION 0x1000 //Big shock looking graphic when starting tumble
+#define WHISTLE 0x20 // Whistle spinout save graphic
+#define CRASH 0x40 //Crash! graphic (vertical tumble)
+#define WHIRRR 0x80 //Whirrr! graphic (spinning out)
+#define POOMP 0x100 //Poomp! graphic (landing from a height)
+#define BOING 0x800 //Boing! graphic (hopping)
+#define EXPLOSION 0x1000 //Big shock looking graphic when starting tumble
 
 
 

--- a/include/defines.h
+++ b/include/defines.h
@@ -329,6 +329,15 @@ enum PLACE { FIRST_PLACE, SECOND_PLACE, THIRD_PLACE, FOURTH_PLACE };
 #define MAX_TIME 0x927C0
 #define DEGREES_CONVERSION_FACTOR 182
 
+/* UNK_002 has something to do with player animations. Each player has a 32-bit
+flag broken into 8 groups of 4 bits. Those 4 bits affect how each of the 8 players
+appear to the specified player */
+#define CHANGING_ANIMATION 0x1 // Seems to be set when the kart animation has to change.
+#define UNK_002_UNKNOWN_0x2 0x2 
+#define UNK_002_UNKNOWN_0x4 0x4 /* Unclear, but has to do with viewing the side of player. At least tends to change if target
+player spins. Something  with avoding rollover of aniamation frame data? */
+#define SIDE_OF_KART 0x8 // Seems to be whether you are in a rectangle shooting out from both sides of target player
+
 #define UNK_0B6_WHISTLE 0x20 // Whistle spinout save graphic
 #define UNK_0B6_CRASH 0x40 //Crash! graphic (vertical tumble)
 #define UNK_0B6_WHIRRR 0x80 //Whirrr! graphic (spinning out)

--- a/include/defines.h
+++ b/include/defines.h
@@ -334,11 +334,11 @@ enum PLACE { FIRST_PLACE, SECOND_PLACE, THIRD_PLACE, FOURTH_PLACE };
 //UNK_0DE
 /* Deals with the lower out of bounds (OOB) plane on levels. Represented by fluids (water / lava)
   or nothing for Rainbow Road and Skyscraper. */
-#define UNK_0DE_UNDER_OOB_OR_FLUID_LEVEL 0x1 // Set while mostly under the plane. Does not necessarily trigger Lakitu on Koopa Troopa Beach.
-#define UNK_0DE_PASS_OOB_OR_FLUID_LEVEL 0x2 // Set when passing through the lower plane in either direction
+#define UNDER_OOB_OR_FLUID_LEVEL 0x1 // Set while mostly under the plane. Does not necessarily trigger Lakitu on Koopa Troopa Beach.
+#define PASS_OOB_OR_FLUID_LEVEL 0x2 // Set when passing through the lower plane in either direction
 // The next two are also activated when passing through the lower plane.
-#define UNK_0DE_UNDER_FLUID_LEVEL 0x4 // Stays active until Lakitu places back on track
-#define UNK_0DE_UNDER_OOB_LEVEL 0x8 // Active while under a non-fluid OOB plane. Is momentarily active when passing through fluids.
+#define UNDER_FLUID_LEVEL 0x4 // Stays active until Lakitu places back on track
+#define UNDER_OOB_LEVEL 0x8 // Active while under a non-fluid OOB plane. Is momentarily active when passing through fluids.
 
 
 /* UNK_002 has something to do with player animations. Each player has a 32-bit

--- a/include/defines.h
+++ b/include/defines.h
@@ -328,6 +328,24 @@ enum PLACE { FIRST_PLACE, SECOND_PLACE, THIRD_PLACE, FOURTH_PLACE };
  */
 #define MAX_TIME 0x927C0
 
+#define UNK_044_BACK_UP 0x1
+#define UNK_044_RIGHT_TURN 0x2 // non-drifting
+#define UNK_044_LEFT_TURN 0x4 // non-drifting
+#define UNK_044_MOVE_BACKWARDS 0x8 // includes lakitu
+#define UNK_044_LOSE_GP_RACE 0x10 // pointless, only unsets itself
+#define UNK_044_PRESS_A 0x20
+//0x40 early spinout right side
+//0x80 early spinout left side
+#define UNK_044_FOO 0x100 //post bomb
+#define UNK_044_BECOME_INVISIBLE 0x200
+#define UNK_044_DRIVING_SPINOUT 0x4000
+//0x8000 something battle related, unclear if ever set
+
+// 0x400 locked behind 0x800 (func_80091440)
+// 0x800 locked behind 0x400 (func_8002B830 -> func_800911B4)
+// 0x2000 locked behind 0x400 and 0x800 (func_8002B830 -> func_800911B4, apply_effect -> func_80091298, func_80091440)
+// 0x1000 locked behind 0x400 (func_8002B830 -> func_800911B4)
+
 /*
  * @brief triggers indicating that an effect should be applied to a kart
  */

--- a/include/defines.h
+++ b/include/defines.h
@@ -93,7 +93,9 @@
  * Used in the Player struct's 'type' member: player->type
  */
 #define PLAYER_INACTIVE 0                 // 0x0000
+#define PLAYER_UNKNOWN_0x10 (1 << 4)      // 0x0010 // unused?
 #define PLAYER_UNKNOWN_0x40 (1 << 6)      // 0x0040
+#define PLAYER_UNKNOWN_0x80 (1 << 7)      // 0x0080 // UNUSED
 #define PLAYER_INVISIBLE_OR_BOMB (1 << 8) // 0x0100
 #define PLAYER_STAGING (1 << 9)           // 0x0200
 #define PLAYER_UNKNOWN (1 << 10)          // 0x0400 // unused ?

--- a/include/defines.h
+++ b/include/defines.h
@@ -334,17 +334,16 @@ enum PLACE { FIRST_PLACE, SECOND_PLACE, THIRD_PLACE, FOURTH_PLACE };
 #define UNK_044_MOVE_BACKWARDS 0x8 // includes lakitu
 #define UNK_044_LOSE_GP_RACE 0x10 // pointless, only unsets itself
 #define UNK_044_PRESS_A 0x20
-//0x40 early spinout right side
-//0x80 early spinout left side
-#define UNK_044_FOO 0x100 //post bomb
+#define UNK_044_EARLY_SPINOUT_RIGHT 0x40 // Spinning out while facing right (not actually used for anything)
+#define UNK_044_EARLY_SPINOUT_LEFT 0x80 // Spinning out while facing left
+#define UNK_044_POST_TUMBLE_GAS 0x100 //Causes particles after a vertical tumble, I think
 #define UNK_044_BECOME_INVISIBLE 0x200
+#define UNK_044_UNUSED_0x400 0x400 //locked behind 0x800 (func_80091440)
+#define UNK_044_UNUSED_0x800 0x800 //locked behind 0x400 (func_8002B830 -> func_800911B4)
+#define UNK_044_UNUSED_0x1000 0x1000 // 0x1000 locked behind 0x400 (func_8002B830 -> func_800911B4)
+#define UNK_044_UNUSED_0x2000 0x2000 // 0x2000 locked behind 0x400 and 0x800 (func_8002B830 -> func_800911B4, apply_effect -> func_80091298, func_80091440)
 #define UNK_044_DRIVING_SPINOUT 0x4000
-//0x8000 something battle related, unclear if ever set
-
-// 0x400 locked behind 0x800 (func_80091440)
-// 0x800 locked behind 0x400 (func_8002B830 -> func_800911B4)
-// 0x2000 locked behind 0x400 and 0x800 (func_8002B830 -> func_800911B4, apply_effect -> func_80091298, func_80091440)
-// 0x1000 locked behind 0x400 (func_8002B830 -> func_800911B4)
+#define UNK_044_UNKNOWN_BATTLE_VAR 0x8000 //0x8000 something battle related, unclear if ever set
 
 /*
  * @brief triggers indicating that an effect should be applied to a kart

--- a/include/defines.h
+++ b/include/defines.h
@@ -370,22 +370,22 @@ player spins. Something  with avoding rollover of aniamation frame data? */
 #define LAKITU_LAVA 0x1000 // smoky effect when retrieved from lava
 #define LAKITU_WATER 0x2000 // dripping effect when retreived from water
 
-#define UNK_044_BACK_UP 0x1
-#define UNK_044_RIGHT_TURN 0x2 // non-drifting (more than 5 degrees)
-#define UNK_044_LEFT_TURN 0x4 // non-drifting (more than 5 degrees)
-#define UNK_044_MOVE_BACKWARDS 0x8 // includes lakitu
-#define UNK_044_LOSE_GP_RACE 0x10 // pointless, only unsets itself
-#define UNK_044_PRESS_A 0x20
-#define UNK_044_EARLY_SPINOUT_RIGHT 0x40 // Spinning out while facing right (not actually used for anything)
-#define UNK_044_EARLY_SPINOUT_LEFT 0x80 // Spinning out while facing left
-#define UNK_044_POST_TUMBLE_GAS 0x100 //Causes particles after a vertical tumble, I think
-#define UNK_044_BECOME_INVISIBLE 0x200
-#define UNK_044_UNUSED_0x400 0x400 //locked behind 0x800 (func_80091440)
-#define UNK_044_UNUSED_0x800 0x800 //locked behind 0x400 (func_8002B830 -> func_800911B4)
-#define UNK_044_UNUSED_0x1000 0x1000 // 0x1000 locked behind 0x400 (func_8002B830 -> func_800911B4)
-#define UNK_044_UNUSED_0x2000 0x2000 // 0x2000 locked behind 0x400 and 0x800 (func_8002B830 -> func_800911B4, apply_effect -> func_80091298, func_80091440)
-#define UNK_044_DRIVING_SPINOUT 0x4000
-#define UNK_044_UNKNOWN_BATTLE_VAR 0x8000 //0x8000 something battle related, unclear if ever set
+#define BACK_UP 0x1
+#define RIGHT_TURN 0x2 // non-drifting (more than 5 degrees)
+#define LEFT_TURN 0x4 // non-drifting (more than 5 degrees)
+#define MOVE_BACKWARDS 0x8 // includes lakitu
+#define LOSE_GP_RACE 0x10 // pointless, only unsets itself
+#define PRESS_A 0x20
+#define EARLY_SPINOUT_RIGHT 0x40 // Spinning out while facing right (not actually used for anything)
+#define EARLY_SPINOUT_LEFT 0x80 // Spinning out while facing left
+#define POST_TUMBLE_GAS 0x100 //Causes particles after a vertical tumble, I think
+#define BECOME_INVISIBLE 0x200
+#define UNUSED_0x400 0x400 //locked behind 0x800 (func_80091440)
+#define UNUSED_0x800 0x800 //locked behind 0x400 (func_8002B830 -> func_800911B4)
+#define UNUSED_0x1000 0x1000 // 0x1000 locked behind 0x400 (func_8002B830 -> func_800911B4)
+#define UNUSED_0x2000 0x2000 // 0x2000 locked behind 0x400 and 0x800 (func_8002B830 -> func_800911B4, apply_effect -> func_80091298, func_80091440)
+#define DRIVING_SPINOUT 0x4000
+#define UNKNOWN_BATTLE_VAR 0x8000 //0x8000 something battle related, unclear if ever set
 
 /*
  * @brief triggers indicating that an effect should be applied to a kart

--- a/include/defines.h
+++ b/include/defines.h
@@ -359,16 +359,16 @@ player spins. Something  with avoding rollover of aniamation frame data? */
 
 
 
-#define UNK_0CA_LAKITU_RETRIEVAL 0x1 // While lakitu is grabbing you, but before the scene transition of being placed on the track
-#define UNK_0CA_HELD_BY_LAKITU 0x2
-#define UNK_0CA_LAKITU_FIZZLE 0x4 // Disintegration and reintegration effect when transitioning from retrieval to placement
-#define UNK_0CA_LAKITU_SCENE 0x8 // the whole segment from when lakitu is called to when you regain control
-#define UNK_0CA_FRIGID_EFFECT 0x10 // Cold colors on Sherbet Land after in frigid water
-#define UNK_0CA_THAWING_EFFECT 0x20 // Regaining usual colors post frigid effect
-#define UNK_0CA_FROZEN_EFFECT 0x80 // In the ice cube
-#define UNK_0CA_WENT_OVER_OOB 0x100 // Player went over (or is on) an OOB area. Cancelled if touch back in bounds
-#define UNK_0CA_LAKITU_LAVA 0x1000 // smoky effect when retrieved from lava
-#define UNK_0CA_LAKITU_WATER 0x2000 // dripping effect when retreived from water
+#define LAKITU_RETRIEVAL 0x1 // While lakitu is grabbing you, but before the scene transition of being placed on the track
+#define HELD_BY_LAKITU 0x2
+#define LAKITU_FIZZLE 0x4 // Disintegration and reintegration effect when transitioning from retrieval to placement
+#define LAKITU_SCENE 0x8 // the whole segment from when lakitu is called to when you regain control
+#define FRIGID_EFFECT 0x10 // Cold colors on Sherbet Land after in frigid water
+#define THAWING_EFFECT 0x20 // Regaining usual colors post frigid effect
+#define FROZEN_EFFECT 0x80 // In the ice cube
+#define WENT_OVER_OOB 0x100 // Player went over (or is on) an OOB area. Cancelled if touch back in bounds
+#define LAKITU_LAVA 0x1000 // smoky effect when retrieved from lava
+#define LAKITU_WATER 0x2000 // dripping effect when retreived from water
 
 #define UNK_044_BACK_UP 0x1
 #define UNK_044_RIGHT_TURN 0x2 // non-drifting (more than 5 degrees)

--- a/include/defines.h
+++ b/include/defines.h
@@ -329,6 +329,14 @@ enum PLACE { FIRST_PLACE, SECOND_PLACE, THIRD_PLACE, FOURTH_PLACE };
 #define MAX_TIME 0x927C0
 #define DEGREES_CONVERSION_FACTOR 182
 
+#define UNK_0B6_WHISTLE 0x20 // Whistle spinout save graphic
+#define UNK_0B6_CRASH 0x40 //Crash! graphic (vertical tumble)
+#define UNK_0B6_WHIRRR 0x80 //Whirrr! graphic (spinning out)
+#define UNK_0B6_POOMP 0x100 //Poomp! graphic (landing from a height)
+#define UNK_0B6_BOING 0x800 //Boing! graphic (hopping)
+#define UNK_0B6_EXPLOSION 0x1000 //Big shock looking graphic when starting tumble
+
+
 
 #define UNK_0CA_LAKITU_RETRIEVAL 0x1 // While lakitu is grabbing you, but before the scene transition of being placed on the track
 #define UNK_0CA_HELD_BY_LAKITU 0x2
@@ -340,9 +348,6 @@ enum PLACE { FIRST_PLACE, SECOND_PLACE, THIRD_PLACE, FOURTH_PLACE };
 #define UNK_0CA_WENT_OVER_OOB 0x100 // Player went over (or is on) an OOB area. Cancelled if touch back in bounds
 #define UNK_0CA_LAKITU_LAVA 0x1000 // smoky effect when retrieved from lava
 #define UNK_0CA_LAKITU_WATER 0x2000 // dripping effect when retreived from water
-
-
-
 
 #define UNK_044_BACK_UP 0x1
 #define UNK_044_RIGHT_TURN 0x2 // non-drifting (more than 5 degrees)

--- a/include/defines.h
+++ b/include/defines.h
@@ -331,7 +331,7 @@ enum PLACE { FIRST_PLACE, SECOND_PLACE, THIRD_PLACE, FOURTH_PLACE };
 #define MAX_TIME 0x927C0
 #define DEGREES_CONVERSION_FACTOR 182
 
-//UNK_0DE
+// UNK_0DE
 /* Deals with the lower out of bounds (OOB) plane on levels. Represented by fluids (water / lava)
   or nothing for Rainbow Road and Skyscraper. */
 #define UNDER_OOB_OR_FLUID_LEVEL 0x1 // Set while mostly under the plane. Does not necessarily trigger Lakitu on Koopa Troopa Beach.
@@ -350,42 +350,43 @@ appear to the specified player */
 player spins. Something  with avoding rollover of aniamation frame data? */
 #define SIDE_OF_KART 0x8 // Seems to be whether you are in a rectangle shooting out from both sides of target player
 
-#define WHISTLE 0x20 // Whistle spinout save graphic
-#define CRASH 0x40 //Crash! graphic (vertical tumble)
-#define WHIRRR 0x80 //Whirrr! graphic (spinning out)
-#define POOMP 0x100 //Poomp! graphic (landing from a height)
-#define BOING 0x800 //Boing! graphic (hopping)
-#define EXPLOSION 0x1000 //Big shock looking graphic when starting tumble
+#define WHISTLE 0x20     // Whistle spinout save graphic
+#define CRASH 0x40       // Crash! graphic (vertical tumble)
+#define WHIRRR 0x80      // Whirrr! graphic (spinning out)
+#define POOMP 0x100      // Poomp! graphic (landing from a height)
+#define BOING 0x800      // Boing! graphic (hopping)
+#define EXPLOSION 0x1000 // Big shock looking graphic when starting tumble
 
 
 
 #define LAKITU_RETRIEVAL 0x1 // While lakitu is grabbing you, but before the scene transition of being placed on the track
-#define HELD_BY_LAKITU 0x2
-#define LAKITU_FIZZLE 0x4 // Disintegration and reintegration effect when transitioning from retrieval to placement
-#define LAKITU_SCENE 0x8 // the whole segment from when lakitu is called to when you regain control
-#define FRIGID_EFFECT 0x10 // Cold colors on Sherbet Land after in frigid water
-#define THAWING_EFFECT 0x20 // Regaining usual colors post frigid effect
-#define FROZEN_EFFECT 0x80 // In the ice cube
-#define WENT_OVER_OOB 0x100 // Player went over (or is on) an OOB area. Cancelled if touch back in bounds
-#define LAKITU_LAVA 0x1000 // smoky effect when retrieved from lava
-#define LAKITU_WATER 0x2000 // dripping effect when retreived from water
+#define HELD_BY_LAKITU   0x2
+#define LAKITU_FIZZLE    0x4 // Disintegration and reintegration effect when transitioning from retrieval to placement
+#define LAKITU_SCENE     0x8 // the whole segment from when lakitu is called to when you regain control
+#define FRIGID_EFFECT   0x10 // Cold colors on Sherbet Land after in frigid water
+#define THAWING_EFFECT  0x20 // Regaining usual colors post frigid effect
+#define FROZEN_EFFECT   0x80 // In the ice cube
+#define WENT_OVER_OOB  0x100 // Player went over (or is on) an OOB area. Cancelled if touch back in bounds
+#define LAKITU_LAVA   0x1000 // smoky effect when retrieved from lava
+#define LAKITU_WATER  0x2000 // dripping effect when retreived from water
 
-#define BACK_UP 0x1
-#define RIGHT_TURN 0x2 // non-drifting (more than 5 degrees)
-#define LEFT_TURN 0x4 // non-drifting (more than 5 degrees)
-#define MOVE_BACKWARDS 0x8 // includes lakitu
-#define LOSE_GP_RACE 0x10 // pointless, only unsets itself
-#define PRESS_A 0x20
-#define EARLY_SPINOUT_RIGHT 0x40 // Spinning out while facing right (not actually used for anything)
-#define EARLY_SPINOUT_LEFT 0x80 // Spinning out while facing left
-#define POST_TUMBLE_GAS 0x100 //Causes particles after a vertical tumble, I think
-#define BECOME_INVISIBLE 0x200
-#define UNUSED_0x400 0x400 //locked behind 0x800 (func_80091440)
-#define UNUSED_0x800 0x800 //locked behind 0x400 (func_8002B830 -> func_800911B4)
-#define UNUSED_0x1000 0x1000 // 0x1000 locked behind 0x400 (func_8002B830 -> func_800911B4)
-#define UNUSED_0x2000 0x2000 // 0x2000 locked behind 0x400 and 0x800 (func_8002B830 -> func_800911B4, apply_effect -> func_80091298, func_80091440)
-#define DRIVING_SPINOUT 0x4000
-#define UNKNOWN_BATTLE_VAR 0x8000 //0x8000 something battle related, unclear if ever set
+#define BACK_UP               0x1
+#define RIGHT_TURN            0x2 // non-drifting (more than 5 degrees)
+#define LEFT_TURN             0x4 // non-drifting (more than 5 degrees)
+#define MOVE_BACKWARDS        0x8 // includes lakitu
+#define LOSE_GP_RACE         0x10 // pointless, only unsets itself
+#define PRESS_A              0x20
+#define EARLY_SPINOUT_RIGHT  0x40 // Spinning out while facing right (not actually used for anything)
+#define EARLY_SPINOUT_LEFT   0x80 // Spinning out while facing left
+#define POST_TUMBLE_GAS     0x100 // Causes particles after a vertical tumble, I think
+#define BECOME_INVISIBLE    0x200
+#define UNUSED_0x400        0x400 // locked behind 0x800 (func_80091440)
+#define UNUSED_0x800        0x800 // locked behind 0x400 (func_8002B830 -> func_800911B4)
+#define UNUSED_0x1000      0x1000 // 0x1000 locked behind 0x400 (func_8002B830 -> func_800911B4)
+#define UNUSED_0x2000      0x2000 // 0x2000 locked behind 0x400 and 0x800 (func_8002B830 -> func_800911B4, apply_effect -> func_80091298,
+                                  // func_80091440)
+#define DRIVING_SPINOUT    0x4000
+#define UNKNOWN_BATTLE_VAR 0x8000 // 0x8000 something battle related, unclear if ever set
 
 /*
  * @brief triggers indicating that an effect should be applied to a kart
@@ -416,11 +417,13 @@ player spins. Something  with avoding rollover of aniamation frame data? */
 
 #define ALL_TRIGGERS (0xFFFFFFFF)
 #define RACING_SPINOUT_TRIGGERS (SPINOUT_TRIGGER | DRIVING_SPINOUT_TRIGGER | HIT_BANANA_TRIGGER) // 0x200081
-#define RAMP_BOOST_TRIGGERS (BOOST_RAMP_ASPHALT_TRIGGER | BOOST_RAMP_WOOD_TRIGGER) // 0x00808000
-#define ANY_BOOST_TRIGGERS (RAMP_BOOST_TRIGGERS | SHROOM_TRIGGER) // 0x00808200
-#define STATE_TRANSITION_TRIGGERS (STAR_TRIGGER | BOO_TRIGGER | UNUSED_TRIGGER_0x1000 | UNUSED_TRIGGER_0x20000)// 0x00023800
-#define HIT_TRIGGERS (HIT_BY_STAR_TRIGGER | VERTICAL_TUMBLE_TRIGGER | \
-    LIGHTNING_STRIKE_TRIGGER | LOW_TUMBLE_TRIGGER | HIGH_TUMBLE_TRIGGER | THWOMP_SQUISH_TRIGGER) // 0x01404106
+#define RAMP_BOOST_TRIGGERS (BOOST_RAMP_ASPHALT_TRIGGER | BOOST_RAMP_WOOD_TRIGGER)               // 0x00808000
+#define ANY_BOOST_TRIGGERS (RAMP_BOOST_TRIGGERS | SHROOM_TRIGGER)                                // 0x00808200
+#define STATE_TRANSITION_TRIGGERS \
+    (STAR_TRIGGER | BOO_TRIGGER | UNUSED_TRIGGER_0x1000 | UNUSED_TRIGGER_0x20000) // 0x00023800
+#define HIT_TRIGGERS                                                                                 \
+    (HIT_BY_STAR_TRIGGER | VERTICAL_TUMBLE_TRIGGER | LIGHTNING_STRIKE_TRIGGER | LOW_TUMBLE_TRIGGER | \
+     HIGH_TUMBLE_TRIGGER | THWOMP_SQUISH_TRIGGER) // 0x01404106
 
 /**
  * @brief effect of player's

--- a/include/defines.h
+++ b/include/defines.h
@@ -375,7 +375,7 @@ player spins. Something  with avoding rollover of aniamation frame data? */
 #define LEFT_TURN             0x4 // non-drifting (more than 5 degrees)
 #define MOVE_BACKWARDS        0x8 // includes lakitu
 #define LOSE_GP_RACE         0x10 // pointless, only unsets itself
-#define PRESS_A              0x20
+#define THROTTLE             0x20 // Closely tied to just pressing A. Possible exception for AB-spins
 #define EARLY_SPINOUT_RIGHT  0x40 // Spinning out while facing right (not actually used for anything)
 #define EARLY_SPINOUT_LEFT   0x80 // Spinning out while facing left
 #define POST_TUMBLE_GAS     0x100 // Causes particles after a vertical tumble, I think

--- a/include/defines.h
+++ b/include/defines.h
@@ -369,7 +369,7 @@ player spins. Something  with avoding rollover of aniamation frame data? */
 #define LAKITU_LAVA   0x1000 // smoky effect when retrieved from lava
 #define LAKITU_WATER  0x2000 // dripping effect when retreived from water
 
-// player->kartGraphics
+// player->kartProps
 #define BACK_UP               0x1
 #define RIGHT_TURN            0x2 // non-drifting (more than 5 degrees)
 #define LEFT_TURN             0x4 // non-drifting (more than 5 degrees)

--- a/include/defines.h
+++ b/include/defines.h
@@ -329,6 +329,16 @@ enum PLACE { FIRST_PLACE, SECOND_PLACE, THIRD_PLACE, FOURTH_PLACE };
 #define MAX_TIME 0x927C0
 #define DEGREES_CONVERSION_FACTOR 182
 
+//UNK_0DE
+/* Deals with the lower out of bounds (OOB) plane on levels. Represented by fluids (water / lava)
+  or nothing for Rainbow Road and Skyscraper. */
+#define UNK_0DE_UNDER_OOB_OR_FLUID_LEVEL 0x1 // Set while mostly under the plane. Does not necessarily trigger Lakitu on Koopa Troopa Beach.
+#define UNK_0DE_PASS_OOB_OR_FLUID_LEVEL 0x2 // Set when passing through the lower plane in either direction
+// The next two are also activated when passing through the lower plane.
+#define UNK_0DE_UNDER_FLUID_LEVEL 0x4 // Stays active until Lakitu places back on track
+#define UNK_0DE_UNDER_OOB_LEVEL 0x8 // Active while under a non-fluid OOB plane. Is momentarily active when passing through fluids.
+
+
 /* UNK_002 has something to do with player animations. Each player has a 32-bit
 flag broken into 8 groups of 4 bits. Those 4 bits affect how each of the 8 players
 appear to the specified player */

--- a/include/defines.h
+++ b/include/defines.h
@@ -329,6 +329,21 @@ enum PLACE { FIRST_PLACE, SECOND_PLACE, THIRD_PLACE, FOURTH_PLACE };
 #define MAX_TIME 0x927C0
 #define DEGREES_CONVERSION_FACTOR 182
 
+
+#define UNK_0CA_LAKITU_RETRIEVAL 0x1 // While lakitu is grabbing you, but before the scene transition of being placed on the track
+#define UNK_0CA_HELD_BY_LAKITU 0x2
+#define UNK_0CA_LAKITU_FIZZLE 0x4 // Disintegration and reintegration effect when transitioning from retrieval to placement
+#define UNK_0CA_LAKITU_SCENE 0x8 // the whole segment from when lakitu is called to when you regain control
+#define UNK_0CA_FRIGID_EFFECT 0x10 // Cold colors on Sherbet Land after in frigid water
+#define UNK_0CA_THAWING_EFFECT 0x20 // Regaining usual colors post frigid effect
+#define UNK_0CA_FROZEN_EFFECT 0x80 // In the ice cube
+#define UNK_0CA_WENT_OVER_OOB 0x100 // Player went over (or is on) an OOB area. Cancelled if touch back in bounds
+#define UNK_0CA_LAKITU_LAVA 0x1000 // smoky effect when retrieved from lava
+#define UNK_0CA_LAKITU_WATER 0x2000 // dripping effect when retreived from water
+
+
+
+
 #define UNK_044_BACK_UP 0x1
 #define UNK_044_RIGHT_TURN 0x2 // non-drifting (more than 5 degrees)
 #define UNK_044_LEFT_TURN 0x4 // non-drifting (more than 5 degrees)

--- a/src/actors/fake_item_box/update.inc.c
+++ b/src/actors/fake_item_box/update.inc.c
@@ -40,7 +40,7 @@ void update_actor_fake_item_box(struct FakeItemBox* fake_item_box) {
                                      fake_item_box->pos[1], fake_item_box->pos[2]);
             func_802B4E30((struct Actor*) fake_item_box);
             temp_v1_3 = &gControllers[temp_v1];
-            if ((temp_v0_4->type & 0x4000) != 0) {
+            if ((temp_v0_4->type & PLAYER_HUMAN) != 0) {
 
                 if ((temp_v1_3->buttonDepressed & Z_TRIG) != 0) {
                     temp_v1_3->buttonDepressed &= 0xDFFF;

--- a/src/audio/external.c
+++ b/src/audio/external.c
@@ -2688,7 +2688,7 @@ void func_800C76C0(u8 playerId) {
 }
 
 void func_800C847C(u8 playerId) {
-    if ((gPlayers[playerId].unk_0DE & 1) == 1) {
+    if ((gPlayers[playerId].unk_0DE & UNK_0DE_UNDER_OOB_OR_FLUID_LEVEL) == UNK_0DE_UNDER_OOB_OR_FLUID_LEVEL) {
         if (D_800E9F74[playerId] == 0) {
             if ((s32) D_800EA1C0 < 2) {
                 func_800C9018(playerId, SOUND_ARG_LOAD(0x01, 0x00, 0xF9, 0x26));

--- a/src/audio/external.c
+++ b/src/audio/external.c
@@ -2380,7 +2380,7 @@ void func_800C70A8(u8 playerId) {
             D_800E9E74[playerId] = 0;
         }
         if ((((gPlayers[playerId].effects & EARLY_START_SPINOUT_EFFECT) == EARLY_START_SPINOUT_EFFECT) &&
-             ((gPlayers[playerId].type & 0x2000) != 0x2000)) ||
+             ((gPlayers[playerId].type & PLAYER_START_SEQUENCE) != PLAYER_START_SEQUENCE)) ||
             ((gPlayers[playerId].effects & BANANA_NEAR_SPINOUT_EFFECT) == BANANA_NEAR_SPINOUT_EFFECT) ||
             ((gPlayers[playerId].effects & BANANA_SPINOUT_EFFECT) == BANANA_SPINOUT_EFFECT) ||
             ((gPlayers[playerId].effects & DRIVING_SPINOUT_EFFECT) == DRIVING_SPINOUT_EFFECT) ||
@@ -2388,7 +2388,7 @@ void func_800C70A8(u8 playerId) {
             D_800E9E74[playerId] = 0x00000012;
         }
         if ((((gPlayers[playerId].effects & AB_SPIN_EFFECT) == AB_SPIN_EFFECT) &&
-             ((gPlayers[playerId].type & 0x2000) != 0x2000)) ||
+             ((gPlayers[playerId].type & PLAYER_START_SEQUENCE) != PLAYER_START_SEQUENCE)) ||
             ((gPlayers[playerId].effects & BANANA_NEAR_SPINOUT_EFFECT) == BANANA_NEAR_SPINOUT_EFFECT)) {
             D_800E9E74[playerId] = 0x00000013;
         }

--- a/src/audio/external.c
+++ b/src/audio/external.c
@@ -1824,7 +1824,7 @@ void func_800C5CB8(void) {
 }
 
 void func_800C5D04(u8 playerId) {
-    if ((gPlayers[playerId].unk_044 & UNK_044_PRESS_A) == UNK_044_PRESS_A) {
+    if ((gPlayers[playerId].kartProps & PRESS_A) == PRESS_A) {
         D_800E9E34[playerId] = 0;
         if (D_800E9E24[playerId] < 0x4E20) {
             if ((u8) D_800EA16C == 0) {
@@ -1853,7 +1853,7 @@ void func_800C5D04(u8 playerId) {
 
 void func_800C5E38(u8 playerId) {
     if (D_800EA108 == 0) {
-        if (((gPlayers[playerId].unk_044 & UNK_044_PRESS_A) != UNK_044_PRESS_A) && (gPlayers[playerId].unk_098 > 400.0f)) {
+        if (((gPlayers[playerId].kartProps & PRESS_A) != PRESS_A) && (gPlayers[playerId].unk_098 > 400.0f)) {
             D_800E9E14[playerId] = 1;
             if (D_800EA0EC[playerId] == 0) {
                 D_800E9F7C[playerId].unk_10 = 0.6f - D_800E9F54[playerId];
@@ -1905,7 +1905,7 @@ void func_800C6108(u8 playerId) {
 
     player = &gPlayers[playerId];
     D_800E9E64[playerId] = (player->unk_098 / D_800E9DC4[playerId]) + D_800E9DD4[playerId];
-    if ((player->unk_098 < 1800.0f) && ((player->unk_044 & UNK_044_PRESS_A) != UNK_044_PRESS_A)) {
+    if ((player->unk_098 < 1800.0f) && ((player->kartProps & PRESS_A) != PRESS_A)) {
         D_800E9E64[playerId] = (player->unk_098 / D_800E9F7C[playerId].unk_34) + D_800E9F7C[playerId].unk_28;
         if (D_800E9EC4) {} // ?
     }
@@ -2003,7 +2003,7 @@ void func_800C64A0(u8 playerId) {
     if (D_800E9EF4[playerId] < 0.0f) {
         D_800E9EF4[playerId] = 0.0f;
     }
-    if ((gPlayers[playerId].unk_044 & UNK_044_PRESS_A) == UNK_044_PRESS_A) {
+    if ((gPlayers[playerId].kartProps & PRESS_A) == PRESS_A) {
         D_800E9F04[playerId] = 0.56f - (D_800E9E24[playerId] * 0.06f);
     } else {
         D_800E9F04[playerId] = (D_800E9E34[playerId] / 50.0f) + 0.25f;
@@ -2384,7 +2384,7 @@ void func_800C70A8(u8 playerId) {
             ((gPlayers[playerId].effects & BANANA_NEAR_SPINOUT_EFFECT) == BANANA_NEAR_SPINOUT_EFFECT) ||
             ((gPlayers[playerId].effects & BANANA_SPINOUT_EFFECT) == BANANA_SPINOUT_EFFECT) ||
             ((gPlayers[playerId].effects & DRIVING_SPINOUT_EFFECT) == DRIVING_SPINOUT_EFFECT) ||
-            ((gPlayers[playerId].unk_044 & UNK_044_DRIVING_SPINOUT) == UNK_044_DRIVING_SPINOUT)) {
+            ((gPlayers[playerId].kartProps & DRIVING_SPINOUT) == DRIVING_SPINOUT)) {
             D_800E9E74[playerId] = 0x00000012;
         }
         if ((((gPlayers[playerId].effects & AB_SPIN_EFFECT) == AB_SPIN_EFFECT) &&

--- a/src/audio/external.c
+++ b/src/audio/external.c
@@ -591,7 +591,7 @@ void func_800C2474(void) {
         gPlayers[var_v0].unk_20C = 0.0f;
         gPlayers[var_v0].unk_0C0 = 0;
         gPlayers[var_v0].unk_098 = 0.0f;
-        gPlayers[var_v0].unk_0DE = 0;
+        gPlayers[var_v0].oobProps = 0;
         D_8018FC10[var_v0][0] = 0x00FF;
         D_8018FC10[var_v0][1] = 0;
         D_800EA10C[var_v0] = 0;
@@ -2688,7 +2688,7 @@ void func_800C76C0(u8 playerId) {
 }
 
 void func_800C847C(u8 playerId) {
-    if ((gPlayers[playerId].unk_0DE & UNK_0DE_UNDER_OOB_OR_FLUID_LEVEL) == UNK_0DE_UNDER_OOB_OR_FLUID_LEVEL) {
+    if ((gPlayers[playerId].oobProps & UNDER_OOB_OR_FLUID_LEVEL) == UNDER_OOB_OR_FLUID_LEVEL) {
         if (D_800E9F74[playerId] == 0) {
             if ((s32) D_800EA1C0 < 2) {
                 func_800C9018(playerId, SOUND_ARG_LOAD(0x01, 0x00, 0xF9, 0x26));

--- a/src/audio/external.c
+++ b/src/audio/external.c
@@ -1824,7 +1824,7 @@ void func_800C5CB8(void) {
 }
 
 void func_800C5D04(u8 playerId) {
-    if ((gPlayers[playerId].kartProps & PRESS_A) == PRESS_A) {
+    if ((gPlayers[playerId].kartProps & THROTTLE) == THROTTLE) {
         D_800E9E34[playerId] = 0;
         if (D_800E9E24[playerId] < 0x4E20) {
             if ((u8) D_800EA16C == 0) {
@@ -1853,7 +1853,7 @@ void func_800C5D04(u8 playerId) {
 
 void func_800C5E38(u8 playerId) {
     if (D_800EA108 == 0) {
-        if (((gPlayers[playerId].kartProps & PRESS_A) != PRESS_A) && (gPlayers[playerId].unk_098 > 400.0f)) {
+        if (((gPlayers[playerId].kartProps & THROTTLE) != THROTTLE) && (gPlayers[playerId].unk_098 > 400.0f)) {
             D_800E9E14[playerId] = 1;
             if (D_800EA0EC[playerId] == 0) {
                 D_800E9F7C[playerId].unk_10 = 0.6f - D_800E9F54[playerId];
@@ -1905,7 +1905,7 @@ void func_800C6108(u8 playerId) {
 
     player = &gPlayers[playerId];
     D_800E9E64[playerId] = (player->unk_098 / D_800E9DC4[playerId]) + D_800E9DD4[playerId];
-    if ((player->unk_098 < 1800.0f) && ((player->kartProps & PRESS_A) != PRESS_A)) {
+    if ((player->unk_098 < 1800.0f) && ((player->kartProps & THROTTLE) != THROTTLE)) {
         D_800E9E64[playerId] = (player->unk_098 / D_800E9F7C[playerId].unk_34) + D_800E9F7C[playerId].unk_28;
         if (D_800E9EC4) {} // ?
     }
@@ -2003,7 +2003,7 @@ void func_800C64A0(u8 playerId) {
     if (D_800E9EF4[playerId] < 0.0f) {
         D_800E9EF4[playerId] = 0.0f;
     }
-    if ((gPlayers[playerId].kartProps & PRESS_A) == PRESS_A) {
+    if ((gPlayers[playerId].kartProps & THROTTLE) == THROTTLE) {
         D_800E9F04[playerId] = 0.56f - (D_800E9E24[playerId] * 0.06f);
     } else {
         D_800E9F04[playerId] = (D_800E9E34[playerId] / 50.0f) + 0.25f;

--- a/src/audio/external.c
+++ b/src/audio/external.c
@@ -1824,7 +1824,7 @@ void func_800C5CB8(void) {
 }
 
 void func_800C5D04(u8 playerId) {
-    if ((gPlayers[playerId].unk_044 & 0x20) == 0x20) {
+    if ((gPlayers[playerId].unk_044 & UNK_044_PRESS_A) == UNK_044_PRESS_A) {
         D_800E9E34[playerId] = 0;
         if (D_800E9E24[playerId] < 0x4E20) {
             if ((u8) D_800EA16C == 0) {
@@ -1853,7 +1853,7 @@ void func_800C5D04(u8 playerId) {
 
 void func_800C5E38(u8 playerId) {
     if (D_800EA108 == 0) {
-        if (((gPlayers[playerId].unk_044 & 0x20) != 0x20) && (gPlayers[playerId].unk_098 > 400.0f)) {
+        if (((gPlayers[playerId].unk_044 & UNK_044_PRESS_A) != UNK_044_PRESS_A) && (gPlayers[playerId].unk_098 > 400.0f)) {
             D_800E9E14[playerId] = 1;
             if (D_800EA0EC[playerId] == 0) {
                 D_800E9F7C[playerId].unk_10 = 0.6f - D_800E9F54[playerId];
@@ -1905,7 +1905,7 @@ void func_800C6108(u8 playerId) {
 
     player = &gPlayers[playerId];
     D_800E9E64[playerId] = (player->unk_098 / D_800E9DC4[playerId]) + D_800E9DD4[playerId];
-    if ((player->unk_098 < 1800.0f) && ((player->unk_044 & 0x20) != 0x20)) {
+    if ((player->unk_098 < 1800.0f) && ((player->unk_044 & UNK_044_PRESS_A) != UNK_044_PRESS_A)) {
         D_800E9E64[playerId] = (player->unk_098 / D_800E9F7C[playerId].unk_34) + D_800E9F7C[playerId].unk_28;
         if (D_800E9EC4) {} // ?
     }
@@ -2003,7 +2003,7 @@ void func_800C64A0(u8 playerId) {
     if (D_800E9EF4[playerId] < 0.0f) {
         D_800E9EF4[playerId] = 0.0f;
     }
-    if ((gPlayers[playerId].unk_044 & 0x20) == 0x20) {
+    if ((gPlayers[playerId].unk_044 & UNK_044_PRESS_A) == UNK_044_PRESS_A) {
         D_800E9F04[playerId] = 0.56f - (D_800E9E24[playerId] * 0.06f);
     } else {
         D_800E9F04[playerId] = (D_800E9E34[playerId] / 50.0f) + 0.25f;

--- a/src/audio/external.c
+++ b/src/audio/external.c
@@ -2384,7 +2384,7 @@ void func_800C70A8(u8 playerId) {
             ((gPlayers[playerId].effects & BANANA_NEAR_SPINOUT_EFFECT) == BANANA_NEAR_SPINOUT_EFFECT) ||
             ((gPlayers[playerId].effects & BANANA_SPINOUT_EFFECT) == BANANA_SPINOUT_EFFECT) ||
             ((gPlayers[playerId].effects & DRIVING_SPINOUT_EFFECT) == DRIVING_SPINOUT_EFFECT) ||
-            ((gPlayers[playerId].unk_044 & 0x4000) == 0x4000)) {
+            ((gPlayers[playerId].unk_044 & UNK_044_DRIVING_SPINOUT) == UNK_044_DRIVING_SPINOUT)) {
             D_800E9E74[playerId] = 0x00000012;
         }
         if ((((gPlayers[playerId].effects & AB_SPIN_EFFECT) == AB_SPIN_EFFECT) &&

--- a/src/camera.c
+++ b/src/camera.c
@@ -988,7 +988,8 @@ void func_8001EE98(Player* player, Camera* camera, s8 index) {
                 func_8001A588(&D_80152300[cameraIndex], camera, player, index, cameraIndex);
                 break;
             case 1:
-                if (((player->lakitu_props & LAKITU_RETRIEVAL) == LAKITU_RETRIEVAL) || ((player->lakitu_props & HELD_BY_LAKITU) == HELD_BY_LAKITU)) {
+                if (((player->lakitu_props & LAKITU_RETRIEVAL) == LAKITU_RETRIEVAL) ||
+                    ((player->lakitu_props & HELD_BY_LAKITU) == HELD_BY_LAKITU)) {
                     func_8001E8E8(camera, player, index);
                     break;
                 }
@@ -999,7 +1000,8 @@ void func_8001EE98(Player* player, Camera* camera, s8 index) {
                 func_8001F87C(cameraIndex);
                 break;
             case 9:
-                if (((player->lakitu_props & LAKITU_RETRIEVAL) == LAKITU_RETRIEVAL) || ((player->lakitu_props & HELD_BY_LAKITU) == HELD_BY_LAKITU)) {
+                if (((player->lakitu_props & LAKITU_RETRIEVAL) == LAKITU_RETRIEVAL) ||
+                    ((player->lakitu_props & HELD_BY_LAKITU) == HELD_BY_LAKITU)) {
                     func_8001E8E8(camera, player, index);
                     break;
                 }
@@ -1150,7 +1152,8 @@ void func_8001F87C(s32 cameraId) {
     if (gActiveScreenMode == SCREEN_MODE_1P) {
         if (gModeSelection == GRAND_PRIX) {
             for (playerIndex = 0; playerIndex < NUM_PLAYERS; playerIndex++) {
-                if ((gPlayerOne[playerIndex].type & PLAYER_STAGING) || (gPlayerOne[playerIndex].type & PLAYER_UNKNOWN_0x80)) {
+                if ((gPlayerOne[playerIndex].type & PLAYER_STAGING) ||
+                    (gPlayerOne[playerIndex].type & PLAYER_UNKNOWN_0x80)) {
                     break;
                 }
                 if (playerIndex == 7) {

--- a/src/camera.c
+++ b/src/camera.c
@@ -330,7 +330,7 @@ void func_8001CCEC(Player* player, Camera* camera, Vec3f arg2, f32* arg3, f32* a
             D_80164A78[index] = D_800DDB30[gActiveScreenMode];
         }
     }
-    if ((player->unk_0CA & UNK_0CA_WENT_OVER_OOB) == UNK_0CA_WENT_OVER_OOB) {
+    if ((player->lakitu_props & WENT_OVER_OOB) == WENT_OVER_OOB) {
         switch (gActiveScreenMode) {
             case SCREEN_MODE_2P_SPLITSCREEN_HORIZONTAL:
             case SCREEN_MODE_2P_SPLITSCREEN_VERTICAL:
@@ -445,7 +445,7 @@ void func_8001D53C(Player* player, Camera* camera, Vec3f arg2, f32* arg3, f32* a
     stackPadding0 = player->pos[0] + sp68[0];
     stackPadding2 = player->pos[2] + sp68[2];
     stackPadding1 = sp68[1] + (player->unk_074 + 1.5);
-    if ((player->unk_0CA & UNK_0CA_LAKITU_RETRIEVAL) == UNK_0CA_LAKITU_RETRIEVAL) {
+    if ((player->lakitu_props & LAKITU_RETRIEVAL) == LAKITU_RETRIEVAL) {
         stackPadding1 = sp68[1] + (thing + 10.0f);
     }
     *arg3 = stackPadding0;
@@ -564,7 +564,7 @@ void func_8001D944(Player* player, Camera* camera, Vec3f arg2, f32* arg3, f32* a
             D_80164A78[index] = D_800DDB30[gActiveScreenMode];
         }
     }
-    if ((player->unk_0CA & UNK_0CA_WENT_OVER_OOB) == UNK_0CA_WENT_OVER_OOB) {
+    if ((player->lakitu_props & WENT_OVER_OOB) == WENT_OVER_OOB) {
 
         move_f32_towards(&D_80164A90[index], 15, 0.02f);
         move_f32_towards(&D_80164AA0[index], 20, 0.02f);
@@ -988,7 +988,7 @@ void func_8001EE98(Player* player, Camera* camera, s8 index) {
                 func_8001A588(&D_80152300[cameraIndex], camera, player, index, cameraIndex);
                 break;
             case 1:
-                if (((player->unk_0CA & UNK_0CA_LAKITU_RETRIEVAL) == UNK_0CA_LAKITU_RETRIEVAL) || ((player->unk_0CA & UNK_0CA_HELD_BY_LAKITU) == UNK_0CA_HELD_BY_LAKITU)) {
+                if (((player->lakitu_props & LAKITU_RETRIEVAL) == LAKITU_RETRIEVAL) || ((player->lakitu_props & HELD_BY_LAKITU) == HELD_BY_LAKITU)) {
                     func_8001E8E8(camera, player, index);
                     break;
                 }
@@ -999,7 +999,7 @@ void func_8001EE98(Player* player, Camera* camera, s8 index) {
                 func_8001F87C(cameraIndex);
                 break;
             case 9:
-                if (((player->unk_0CA & UNK_0CA_LAKITU_RETRIEVAL) == UNK_0CA_LAKITU_RETRIEVAL) || ((player->unk_0CA & UNK_0CA_HELD_BY_LAKITU) == UNK_0CA_HELD_BY_LAKITU)) {
+                if (((player->lakitu_props & LAKITU_RETRIEVAL) == LAKITU_RETRIEVAL) || ((player->lakitu_props & HELD_BY_LAKITU) == HELD_BY_LAKITU)) {
                     func_8001E8E8(camera, player, index);
                     break;
                 }

--- a/src/camera.c
+++ b/src/camera.c
@@ -1150,7 +1150,7 @@ void func_8001F87C(s32 cameraId) {
     if (gActiveScreenMode == SCREEN_MODE_1P) {
         if (gModeSelection == GRAND_PRIX) {
             for (playerIndex = 0; playerIndex < NUM_PLAYERS; playerIndex++) {
-                if ((gPlayerOne[playerIndex].type & 0x200) || (gPlayerOne[playerIndex].type & 0x80)) {
+                if ((gPlayerOne[playerIndex].type & PLAYER_STAGING) || (gPlayerOne[playerIndex].type & PLAYER_UNKNOWN_0x80)) {
                     break;
                 }
                 if (playerIndex == 7) {

--- a/src/camera.c
+++ b/src/camera.c
@@ -330,7 +330,7 @@ void func_8001CCEC(Player* player, Camera* camera, Vec3f arg2, f32* arg3, f32* a
             D_80164A78[index] = D_800DDB30[gActiveScreenMode];
         }
     }
-    if ((player->lakitu_props & WENT_OVER_OOB) == WENT_OVER_OOB) {
+    if ((player->lakituProps & WENT_OVER_OOB) == WENT_OVER_OOB) {
         switch (gActiveScreenMode) {
             case SCREEN_MODE_2P_SPLITSCREEN_HORIZONTAL:
             case SCREEN_MODE_2P_SPLITSCREEN_VERTICAL:
@@ -445,7 +445,7 @@ void func_8001D53C(Player* player, Camera* camera, Vec3f arg2, f32* arg3, f32* a
     stackPadding0 = player->pos[0] + sp68[0];
     stackPadding2 = player->pos[2] + sp68[2];
     stackPadding1 = sp68[1] + (player->unk_074 + 1.5);
-    if ((player->lakitu_props & LAKITU_RETRIEVAL) == LAKITU_RETRIEVAL) {
+    if ((player->lakituProps & LAKITU_RETRIEVAL) == LAKITU_RETRIEVAL) {
         stackPadding1 = sp68[1] + (thing + 10.0f);
     }
     *arg3 = stackPadding0;
@@ -564,7 +564,7 @@ void func_8001D944(Player* player, Camera* camera, Vec3f arg2, f32* arg3, f32* a
             D_80164A78[index] = D_800DDB30[gActiveScreenMode];
         }
     }
-    if ((player->lakitu_props & WENT_OVER_OOB) == WENT_OVER_OOB) {
+    if ((player->lakituProps & WENT_OVER_OOB) == WENT_OVER_OOB) {
 
         move_f32_towards(&D_80164A90[index], 15, 0.02f);
         move_f32_towards(&D_80164AA0[index], 20, 0.02f);
@@ -988,8 +988,8 @@ void func_8001EE98(Player* player, Camera* camera, s8 index) {
                 func_8001A588(&D_80152300[cameraIndex], camera, player, index, cameraIndex);
                 break;
             case 1:
-                if (((player->lakitu_props & LAKITU_RETRIEVAL) == LAKITU_RETRIEVAL) ||
-                    ((player->lakitu_props & HELD_BY_LAKITU) == HELD_BY_LAKITU)) {
+                if (((player->lakituProps & LAKITU_RETRIEVAL) == LAKITU_RETRIEVAL) ||
+                    ((player->lakituProps & HELD_BY_LAKITU) == HELD_BY_LAKITU)) {
                     func_8001E8E8(camera, player, index);
                     break;
                 }
@@ -1000,8 +1000,8 @@ void func_8001EE98(Player* player, Camera* camera, s8 index) {
                 func_8001F87C(cameraIndex);
                 break;
             case 9:
-                if (((player->lakitu_props & LAKITU_RETRIEVAL) == LAKITU_RETRIEVAL) ||
-                    ((player->lakitu_props & HELD_BY_LAKITU) == HELD_BY_LAKITU)) {
+                if (((player->lakituProps & LAKITU_RETRIEVAL) == LAKITU_RETRIEVAL) ||
+                    ((player->lakituProps & HELD_BY_LAKITU) == HELD_BY_LAKITU)) {
                     func_8001E8E8(camera, player, index);
                     break;
                 }

--- a/src/camera.c
+++ b/src/camera.c
@@ -330,7 +330,7 @@ void func_8001CCEC(Player* player, Camera* camera, Vec3f arg2, f32* arg3, f32* a
             D_80164A78[index] = D_800DDB30[gActiveScreenMode];
         }
     }
-    if ((player->unk_0CA & 0x100) == 0x100) {
+    if ((player->unk_0CA & UNK_0CA_WENT_OVER_OOB) == UNK_0CA_WENT_OVER_OOB) {
         switch (gActiveScreenMode) {
             case SCREEN_MODE_2P_SPLITSCREEN_HORIZONTAL:
             case SCREEN_MODE_2P_SPLITSCREEN_VERTICAL:
@@ -445,7 +445,7 @@ void func_8001D53C(Player* player, Camera* camera, Vec3f arg2, f32* arg3, f32* a
     stackPadding0 = player->pos[0] + sp68[0];
     stackPadding2 = player->pos[2] + sp68[2];
     stackPadding1 = sp68[1] + (player->unk_074 + 1.5);
-    if ((player->unk_0CA & 1) == 1) {
+    if ((player->unk_0CA & UNK_0CA_LAKITU_RETRIEVAL) == UNK_0CA_LAKITU_RETRIEVAL) {
         stackPadding1 = sp68[1] + (thing + 10.0f);
     }
     *arg3 = stackPadding0;
@@ -564,7 +564,7 @@ void func_8001D944(Player* player, Camera* camera, Vec3f arg2, f32* arg3, f32* a
             D_80164A78[index] = D_800DDB30[gActiveScreenMode];
         }
     }
-    if ((player->unk_0CA & 0x100) == 0x100) {
+    if ((player->unk_0CA & UNK_0CA_WENT_OVER_OOB) == UNK_0CA_WENT_OVER_OOB) {
 
         move_f32_towards(&D_80164A90[index], 15, 0.02f);
         move_f32_towards(&D_80164AA0[index], 20, 0.02f);
@@ -988,7 +988,7 @@ void func_8001EE98(Player* player, Camera* camera, s8 index) {
                 func_8001A588(&D_80152300[cameraIndex], camera, player, index, cameraIndex);
                 break;
             case 1:
-                if (((player->unk_0CA & 1) == 1) || ((player->unk_0CA & 2) == 2)) {
+                if (((player->unk_0CA & UNK_0CA_LAKITU_RETRIEVAL) == UNK_0CA_LAKITU_RETRIEVAL) || ((player->unk_0CA & UNK_0CA_HELD_BY_LAKITU) == UNK_0CA_HELD_BY_LAKITU)) {
                     func_8001E8E8(camera, player, index);
                     break;
                 }
@@ -999,7 +999,7 @@ void func_8001EE98(Player* player, Camera* camera, s8 index) {
                 func_8001F87C(cameraIndex);
                 break;
             case 9:
-                if (((player->unk_0CA & 1) == 1) || ((player->unk_0CA & 2) == 2)) {
+                if (((player->unk_0CA & UNK_0CA_LAKITU_RETRIEVAL) == UNK_0CA_LAKITU_RETRIEVAL) || ((player->unk_0CA & UNK_0CA_HELD_BY_LAKITU) == UNK_0CA_HELD_BY_LAKITU)) {
                     func_8001E8E8(camera, player, index);
                     break;
                 }

--- a/src/camera.c
+++ b/src/camera.c
@@ -400,7 +400,7 @@ void func_8001CCEC(Player* player, Camera* camera, Vec3f arg2, f32* arg3, f32* a
         *arg4 = camera->pos[1] + (((y - camera->pos[1]) * 0.15));
     }
 
-    if ((player->unk_0DE & 1) != 0) {
+    if ((player->unk_0DE & UNK_0DE_UNDER_OOB_OR_FLUID_LEVEL) != 0) {
         *arg4 = D_801652A0[index];
     }
 }
@@ -620,7 +620,7 @@ void func_8001D944(Player* player, Camera* camera, Vec3f arg2, f32* arg3, f32* a
         *arg4 = camera->pos[1] + (((y - camera->pos[1]) * 0.15));
     }
 
-    if ((player->unk_0DE & 1) != 0) {
+    if ((player->unk_0DE & UNK_0DE_UNDER_OOB_OR_FLUID_LEVEL) != 0) {
         *arg4 = D_801652A0[index];
     }
 }

--- a/src/camera.c
+++ b/src/camera.c
@@ -400,7 +400,7 @@ void func_8001CCEC(Player* player, Camera* camera, Vec3f arg2, f32* arg3, f32* a
         *arg4 = camera->pos[1] + (((y - camera->pos[1]) * 0.15));
     }
 
-    if ((player->unk_0DE & UNK_0DE_UNDER_OOB_OR_FLUID_LEVEL) != 0) {
+    if ((player->oobProps & UNDER_OOB_OR_FLUID_LEVEL) != 0) {
         *arg4 = D_801652A0[index];
     }
 }
@@ -620,7 +620,7 @@ void func_8001D944(Player* player, Camera* camera, Vec3f arg2, f32* arg3, f32* a
         *arg4 = camera->pos[1] + (((y - camera->pos[1]) * 0.15));
     }
 
-    if ((player->unk_0DE & UNK_0DE_UNDER_OOB_OR_FLUID_LEVEL) != 0) {
+    if ((player->oobProps & UNDER_OOB_OR_FLUID_LEVEL) != 0) {
         *arg4 = D_801652A0[index];
     }
 }

--- a/src/code_8003DC40.c
+++ b/src/code_8003DC40.c
@@ -204,7 +204,7 @@ void func_8003F138(Player* player, Vec3f arg1, Vec3f arg2, Vec3f arg3, f32* arg4
     *arg7 += arg1[2] * player->collision.surfaceDistance[2] * 1;
     func_8002A5F4(arg1, *arg4, arg2, 0.5f, 2);
     if (player->surfaceType == GRASS) {
-        player->unk_044 &= ~1;
+        player->unk_044 &= ~UNK_044_BACK_UP;
     }
     if (player->collision.orientationVector[1] <= 0.8357f) {
         arg3[0] = ((player->unk_206 / 182) * 0xC8);

--- a/src/code_8003DC40.c
+++ b/src/code_8003DC40.c
@@ -230,7 +230,7 @@ void func_8003F46C(Player* player, Vec3f arg1, Vec3f arg2, Vec3f arg3, f32* arg4
     arg1[0] = -player->collision.orientationVector[0];
     arg1[1] = -player->collision.orientationVector[1];
     arg1[2] = -player->collision.orientationVector[2];
-    if ((player->collision.orientationVector[1] < 0.0f) && ((player->unk_0CA & UNK_0CA_HELD_BY_LAKITU) == 0)) {
+    if ((player->collision.orientationVector[1] < 0.0f) && ((player->lakitu_props & HELD_BY_LAKITU) == 0)) {
         *arg5 += arg1[0] * player->collision.surfaceDistance[2] * 1;
         *arg6 += arg1[1] * player->collision.surfaceDistance[2] * 1;
         *arg7 += arg1[2] * player->collision.surfaceDistance[2] * 1;

--- a/src/code_8003DC40.c
+++ b/src/code_8003DC40.c
@@ -230,7 +230,7 @@ void func_8003F46C(Player* player, Vec3f arg1, Vec3f arg2, Vec3f arg3, f32* arg4
     arg1[0] = -player->collision.orientationVector[0];
     arg1[1] = -player->collision.orientationVector[1];
     arg1[2] = -player->collision.orientationVector[2];
-    if ((player->collision.orientationVector[1] < 0.0f) && ((player->unk_0CA & 2) == 0)) {
+    if ((player->collision.orientationVector[1] < 0.0f) && ((player->unk_0CA & UNK_0CA_HELD_BY_LAKITU) == 0)) {
         *arg5 += arg1[0] * player->collision.surfaceDistance[2] * 1;
         *arg6 += arg1[1] * player->collision.surfaceDistance[2] * 1;
         *arg7 += arg1[2] * player->collision.surfaceDistance[2] * 1;

--- a/src/code_8003DC40.c
+++ b/src/code_8003DC40.c
@@ -230,7 +230,7 @@ void func_8003F46C(Player* player, Vec3f arg1, Vec3f arg2, Vec3f arg3, f32* arg4
     arg1[0] = -player->collision.orientationVector[0];
     arg1[1] = -player->collision.orientationVector[1];
     arg1[2] = -player->collision.orientationVector[2];
-    if ((player->collision.orientationVector[1] < 0.0f) && ((player->lakitu_props & HELD_BY_LAKITU) == 0)) {
+    if ((player->collision.orientationVector[1] < 0.0f) && ((player->lakituProps & HELD_BY_LAKITU) == 0)) {
         *arg5 += arg1[0] * player->collision.surfaceDistance[2] * 1;
         *arg6 += arg1[1] * player->collision.surfaceDistance[2] * 1;
         *arg7 += arg1[2] * player->collision.surfaceDistance[2] * 1;

--- a/src/code_8003DC40.c
+++ b/src/code_8003DC40.c
@@ -204,7 +204,7 @@ void func_8003F138(Player* player, Vec3f arg1, Vec3f arg2, Vec3f arg3, f32* arg4
     *arg7 += arg1[2] * player->collision.surfaceDistance[2] * 1;
     func_8002A5F4(arg1, *arg4, arg2, 0.5f, 2);
     if (player->surfaceType == GRASS) {
-        player->unk_044 &= ~UNK_044_BACK_UP;
+        player->kartProps &= ~BACK_UP;
     }
     if (player->collision.orientationVector[1] <= 0.8357f) {
         arg3[0] = ((player->unk_206 / 182) * 0xC8);

--- a/src/code_80057C60.c
+++ b/src/code_80057C60.c
@@ -6437,7 +6437,9 @@ void func_8006CEC0(Player* arg0, s16 arg1, s8 arg2, s8 arg3) {
                 if (((arg0->effects & SQUISH_EFFECT) != SQUISH_EFFECT) &&
                     ((arg0->effects & HIT_BY_GREEN_SHELL_EFFECT) != HIT_BY_GREEN_SHELL_EFFECT) &&
                     ((arg0->effects & EXPLOSION_CRASH_EFFECT) != EXPLOSION_CRASH_EFFECT)) {
-                    if (((arg0->lakitu_props & HELD_BY_LAKITU) != HELD_BY_LAKITU) && ((arg0->lakitu_props & FRIGID_EFFECT) != FRIGID_EFFECT) && !(arg0->lakitu_props & WENT_OVER_OOB)) {
+                    if (((arg0->lakitu_props & HELD_BY_LAKITU) != HELD_BY_LAKITU) &&
+                        ((arg0->lakitu_props & FRIGID_EFFECT) != FRIGID_EFFECT) &&
+                        !(arg0->lakitu_props & WENT_OVER_OOB)) {
                         func_80060504(arg0, arg1, sp20, arg2, arg3);
                     }
                 }
@@ -6447,13 +6449,15 @@ void func_8006CEC0(Player* arg0, s16 arg1, s8 arg2, s8 arg3) {
             case SCREEN_MODE_2P_SPLITSCREEN_HORIZONTAL:
             case SCREEN_MODE_2P_SPLITSCREEN_VERTICAL:
             case SCREEN_MODE_3P_4P_SPLITSCREEN:
-            if (((arg0->type & PLAYER_HUMAN) != 0) && ((arg0->effects & SQUISH_EFFECT) != SQUISH_EFFECT) &&
-                ((arg0->effects & HIT_BY_GREEN_SHELL_EFFECT) != HIT_BY_GREEN_SHELL_EFFECT) &&
-                ((arg0->effects & EXPLOSION_CRASH_EFFECT) != EXPLOSION_CRASH_EFFECT)) {
-                if (((arg0->lakitu_props & HELD_BY_LAKITU) != HELD_BY_LAKITU) && ((arg0->lakitu_props & FRIGID_EFFECT) != FRIGID_EFFECT) && !(arg0->lakitu_props & WENT_OVER_OOB)) {
-                    func_80060504(arg0, arg1, sp20, arg2, arg3);
+                if (((arg0->type & PLAYER_HUMAN) != 0) && ((arg0->effects & SQUISH_EFFECT) != SQUISH_EFFECT) &&
+                    ((arg0->effects & HIT_BY_GREEN_SHELL_EFFECT) != HIT_BY_GREEN_SHELL_EFFECT) &&
+                    ((arg0->effects & EXPLOSION_CRASH_EFFECT) != EXPLOSION_CRASH_EFFECT)) {
+                    if (((arg0->lakitu_props & HELD_BY_LAKITU) != HELD_BY_LAKITU) &&
+                        ((arg0->lakitu_props & FRIGID_EFFECT) != FRIGID_EFFECT) &&
+                        !(arg0->lakitu_props & WENT_OVER_OOB)) {
+                        func_80060504(arg0, arg1, sp20, arg2, arg3);
+                    }
                 }
-            }
             break;
         }
     }

--- a/src/code_80057C60.c
+++ b/src/code_80057C60.c
@@ -4171,7 +4171,7 @@ void func_80062A18(Player* player, s8 arg1, UNUSED s8 arg2, s8 arg3) {
     player->particles[20 + arg1 /* arg1 instead of arg3 */].scale = 0.2f;
     player->particles[20 + arg3].timer = 1;
     player->particles[20 + arg3].rotation = 0;
-    player->unk_0B6 &= ~UNK_0B6_WHIRRR;
+    player->kart_graphics &= ~WHIRRR;
     player->particles[20 + arg3].pos[2] = player->pos[2];
     player->particles[20 + arg3].pos[0] = player->pos[0];
     player->particles[20 + arg3].pos[1] = (player->pos[1] + 4.0f);
@@ -4862,7 +4862,7 @@ void func_80064DEC(Player* player, UNUSED s8 arg1, UNUSED s8 arg2, s8 arg3) {
     ++player->particles[20 + arg3].timer;
 
     if (player->particles[20 + arg3].timer == 9) {
-        player->unk_0B6 &= ~UNK_0B6_CRASH;
+        player->kart_graphics &= ~CRASH;
         player->particles[20 + arg3].IsAlive = 0;
         player->particles[20 + arg3].timer = 0;
         player->particles[20 + arg3].type = 0;
@@ -4884,7 +4884,7 @@ void func_80064EA4(Player* player, UNUSED s8 arg1, UNUSED s8 arg2, s8 arg3) {
     } else {
         player->particles[20 + arg3].scale -= 1.8;
         if (player->particles[20 + arg3].scale <= 0.0f) {
-            player->unk_0B6 &= ~UNK_0B6_EXPLOSION;
+            player->kart_graphics &= ~EXPLOSION;
             player->particles[20 + arg3].IsAlive = 0;
             player->particles[20 + arg3].timer = 0;
             player->particles[20 + arg3].type = 0;
@@ -4900,7 +4900,7 @@ void func_80064F88(Player* player, UNUSED s8 arg1, UNUSED s8 arg2, s8 arg3) {
         player->particles[20 + arg3].scale = 1.2f;
     }
     if (player->particles[20 + arg3].timer >= 12) {
-        player->unk_0B6 &= ~UNK_0B6_BOING;
+        player->kart_graphics &= ~BOING;
         player->particles[20 + arg3].IsAlive = 0;
         player->particles[20 + arg3].timer = 0;
         player->particles[20 + arg3].type = 0;
@@ -4917,7 +4917,7 @@ void func_80065030(Player* player, UNUSED s8 arg1, UNUSED s8 arg2, s8 arg3) {
     }
 
     if (player->particles[20 + arg3].timer >= 12) {
-        player->unk_0B6 &= ~UNK_0B6_POOMP;
+        player->kart_graphics &= ~POOMP;
         player->particles[20 + arg3].IsAlive = 0;
         player->particles[20 + arg3].timer = 0;
         player->particles[20 + arg3].type = 0;
@@ -4957,7 +4957,7 @@ void func_800651F4(Player* player, UNUSED s8 arg1, UNUSED s8 arg2, s8 arg3) {
     } else {
         player->particles[20 + arg3].scale -= 0.4;
         if (player->particles[20 + arg3].scale <= 0.0f) {
-            player->unk_0B6 &= ~UNK_0B6_WHISTLE;
+            player->kart_graphics &= ~WHISTLE;
             player->particles[20 + arg3].IsAlive = 0;
             player->particles[20 + arg3].timer = 0;
             player->particles[20 + arg3].type = 0;
@@ -6479,19 +6479,19 @@ void func_8006D194(Player* player, s8 playerIndex, s8 arg2) {
                 break;
         }
     } else {
-        if ((player->unk_0B6 & UNK_0B6_CRASH) == UNK_0B6_CRASH) {
+        if ((player->kart_graphics & CRASH) == CRASH) {
             func_800628C0(player, playerIndex, arg2, 0);
         }
-        if ((player->unk_0B6 & UNK_0B6_BOING) == UNK_0B6_BOING) {
+        if ((player->kart_graphics & BOING) == BOING) {
             func_80062968(player, playerIndex, arg2, 0);
         }
-        if ((player->unk_0B6 & UNK_0B6_EXPLOSION) == UNK_0B6_EXPLOSION) {
+        if ((player->kart_graphics & EXPLOSION) == EXPLOSION) {
             func_80062914(player, playerIndex, arg2, 0);
         }
-        if ((player->unk_0B6 & UNK_0B6_WHIRRR) == UNK_0B6_WHIRRR) {
+        if ((player->kart_graphics & WHIRRR) == WHIRRR) {
             func_80062A18(player, playerIndex, arg2, 0);
         }
-        if ((player->unk_0B6 & UNK_0B6_POOMP) == UNK_0B6_POOMP) {
+        if ((player->kart_graphics & POOMP) == POOMP) {
             func_800629BC(player, playerIndex, arg2, 0);
         }
     }
@@ -6499,7 +6499,7 @@ void func_8006D194(Player* player, s8 playerIndex, s8 arg2) {
         if (player->particles[0x15].type == 5) {
             func_800651F4(player, playerIndex, arg2, 1);
         }
-    } else if ((player->unk_0B6 & UNK_0B6_WHISTLE) == UNK_0B6_WHISTLE) {
+    } else if ((player->kart_graphics & WHISTLE) == WHISTLE) {
         func_80062AA8(player, playerIndex, arg2, 1);
     }
 }

--- a/src/code_80057C60.c
+++ b/src/code_80057C60.c
@@ -3628,7 +3628,7 @@ void func_800608E0(Player* player, s16 arg1, UNUSED s32 arg2, s8 arg3, UNUSED s8
         var_f0 = 0.0f;
     }
     sp4C = (D_801652A0[arg3] - player->pos[1]) - 3.0f;
-    if ((player->unk_0DE & UNK_0DE_UNDER_OOB_OR_FLUID_LEVEL) && (gCurrentCourseId != COURSE_KOOPA_BEACH)) {
+    if ((player->oobProps & UNDER_OOB_OR_FLUID_LEVEL) && (gCurrentCourseId != COURSE_KOOPA_BEACH)) {
         var_f0 = 2.5f;
         sp4C = (f32) ((f64) (D_801652A0[arg3] - player->pos[1]) + 0.1);
     }
@@ -3711,7 +3711,7 @@ void func_80060F50(Player* player, s16 arg1, UNUSED s32 arg2, s8 arg3, UNUSED s8
     player->particles[arg1].pos[2] = player->pos[2] + (coss(player->particles[arg1].rotation) * -5.8);
     player->particles[arg1].pos[0] = player->pos[0] + (sins(player->particles[arg1].rotation) * -5.8);
     player->particles[arg1].pos[1] = D_801652A0[arg3];
-    player->unk_0DE &= ~UNK_0DE_UNDER_OOB_LEVEL;
+    player->oobProps &= ~UNDER_OOB_LEVEL;
 }
 
 void func_80061094(Player* player, s16 arg1, UNUSED s32 arg2, UNUSED s8 arg3, UNUSED s8 arg4) {
@@ -4618,7 +4618,7 @@ void func_80064184(Player* player, s16 arg1, s8 arg2, UNUSED s8 arg3) {
     f32 sp3C;
 
     sp40 = D_801652A0[arg2] - player->pos[1] - 3.0f;
-    if (((player->unk_0DE & UNK_0DE_UNDER_OOB_OR_FLUID_LEVEL) != 0) && (gCurrentCourseId != COURSE_KOOPA_BEACH)) {
+    if (((player->oobProps & UNDER_OOB_OR_FLUID_LEVEL) != 0) && (gCurrentCourseId != COURSE_KOOPA_BEACH)) {
         sp40 = D_801652A0[arg2] - player->pos[1] + 0.1;
     }
 
@@ -6263,7 +6263,7 @@ void func_8006C6AC(Player* player, s16 arg1, s8 arg2, s8 arg3) {
                 break;
         }
     } else {
-        if (player->unk_0DE & UNK_0DE_UNDER_OOB_OR_FLUID_LEVEL) {
+        if (player->oobProps & UNDER_OOB_OR_FLUID_LEVEL) {
             func_80060BCC(player, arg1, sp28, arg2_copy, arg3);
         } else if (!(player->effects & MIDAIR_EFFECT) && !(player->effects & HOP_EFFECT)) {
             if (((player->effects & DRIFTING_EFFECT) == DRIFTING_EFFECT) &&
@@ -6424,10 +6424,10 @@ void func_8006CEC0(Player* arg0, s16 arg1, s8 arg2, s8 arg3) {
             func_80061094(arg0, arg1, sp20, arg2, arg3);
             return;
         } else if ((arg0->type & PLAYER_HUMAN) == PLAYER_HUMAN) {
-            if ((arg0->unk_0DE & UNK_0DE_UNDER_OOB_LEVEL) == UNK_0DE_UNDER_OOB_LEVEL) {
+            if ((arg0->oobProps & UNDER_OOB_LEVEL) == UNDER_OOB_LEVEL) {
                 func_80060F50(arg0, arg1, sp20, arg2, arg3);
                 return;
-            } else if ((arg0->unk_0DE & UNK_0DE_PASS_OOB_OR_FLUID_LEVEL) || (arg0->unk_0DE & UNK_0DE_UNDER_OOB_OR_FLUID_LEVEL)) {
+            } else if ((arg0->oobProps & PASS_OOB_OR_FLUID_LEVEL) || (arg0->oobProps & UNDER_OOB_OR_FLUID_LEVEL)) {
                 func_80060B14(arg0, arg1, sp20, arg2, arg3);
                 return;
             }

--- a/src/code_80057C60.c
+++ b/src/code_80057C60.c
@@ -4171,7 +4171,7 @@ void func_80062A18(Player* player, s8 arg1, UNUSED s8 arg2, s8 arg3) {
     player->particles[20 + arg1 /* arg1 instead of arg3 */].scale = 0.2f;
     player->particles[20 + arg3].timer = 1;
     player->particles[20 + arg3].rotation = 0;
-    player->kart_graphics &= ~WHIRRR;
+    player->kartGraphics &= ~WHIRRR;
     player->particles[20 + arg3].pos[2] = player->pos[2];
     player->particles[20 + arg3].pos[0] = player->pos[0];
     player->particles[20 + arg3].pos[1] = (player->pos[1] + 4.0f);
@@ -4282,7 +4282,7 @@ void func_80062F98(Player* player, s16 arg1, s8 arg2, UNUSED s8 arg3) {
     temp_f0 = player->particles[10 + arg1].unk_018 / 10.0f;
     ++player->particles[10 + arg1].timer;
     player->particles[10 + arg1].pos[1] += temp_f0;
-    if ((player->lakitu_props & LAKITU_RETRIEVAL) == LAKITU_RETRIEVAL) {
+    if ((player->lakituProps & LAKITU_RETRIEVAL) == LAKITU_RETRIEVAL) {
         player->particles[10 + arg1].pos[1] += (temp_f0 + 0.3);
         if ((player->particles[10 + arg1].timer == 0x10) ||
             ((D_801652A0[arg2] - player->particles[10 + arg1].pos[1]) < 3.0f)) {
@@ -4862,7 +4862,7 @@ void func_80064DEC(Player* player, UNUSED s8 arg1, UNUSED s8 arg2, s8 arg3) {
     ++player->particles[20 + arg3].timer;
 
     if (player->particles[20 + arg3].timer == 9) {
-        player->kart_graphics &= ~CRASH;
+        player->kartGraphics &= ~CRASH;
         player->particles[20 + arg3].IsAlive = 0;
         player->particles[20 + arg3].timer = 0;
         player->particles[20 + arg3].type = 0;
@@ -4884,7 +4884,7 @@ void func_80064EA4(Player* player, UNUSED s8 arg1, UNUSED s8 arg2, s8 arg3) {
     } else {
         player->particles[20 + arg3].scale -= 1.8;
         if (player->particles[20 + arg3].scale <= 0.0f) {
-            player->kart_graphics &= ~EXPLOSION;
+            player->kartGraphics &= ~EXPLOSION;
             player->particles[20 + arg3].IsAlive = 0;
             player->particles[20 + arg3].timer = 0;
             player->particles[20 + arg3].type = 0;
@@ -4900,7 +4900,7 @@ void func_80064F88(Player* player, UNUSED s8 arg1, UNUSED s8 arg2, s8 arg3) {
         player->particles[20 + arg3].scale = 1.2f;
     }
     if (player->particles[20 + arg3].timer >= 12) {
-        player->kart_graphics &= ~BOING;
+        player->kartGraphics &= ~BOING;
         player->particles[20 + arg3].IsAlive = 0;
         player->particles[20 + arg3].timer = 0;
         player->particles[20 + arg3].type = 0;
@@ -4917,7 +4917,7 @@ void func_80065030(Player* player, UNUSED s8 arg1, UNUSED s8 arg2, s8 arg3) {
     }
 
     if (player->particles[20 + arg3].timer >= 12) {
-        player->kart_graphics &= ~POOMP;
+        player->kartGraphics &= ~POOMP;
         player->particles[20 + arg3].IsAlive = 0;
         player->particles[20 + arg3].timer = 0;
         player->particles[20 + arg3].type = 0;
@@ -4957,7 +4957,7 @@ void func_800651F4(Player* player, UNUSED s8 arg1, UNUSED s8 arg2, s8 arg3) {
     } else {
         player->particles[20 + arg3].scale -= 0.4;
         if (player->particles[20 + arg3].scale <= 0.0f) {
-            player->kart_graphics &= ~WHISTLE;
+            player->kartGraphics &= ~WHISTLE;
             player->particles[20 + arg3].IsAlive = 0;
             player->particles[20 + arg3].timer = 0;
             player->particles[20 + arg3].type = 0;
@@ -6340,7 +6340,7 @@ void func_8006C9B8(Player* player, s16 arg1, s8 playerIndex, s8 arg3) {
             player->kartProps &= ~POST_TUMBLE_GAS;
             return;
         }
-        if (((((player->lakitu_props & LAKITU_LAVA) == LAKITU_LAVA) ||
+        if (((((player->lakituProps & LAKITU_LAVA) == LAKITU_LAVA) ||
               ((player->unk_0E0 < 2) && (player->effects & EXPLOSION_CRASH_EFFECT))) ||
              ((player->unk_0E0 < 2) && (player->effects & HIT_BY_STAR_EFFECT))) ||
             (player->effects & HIT_BY_GREEN_SHELL_EFFECT)) {
@@ -6349,7 +6349,7 @@ void func_8006C9B8(Player* player, s16 arg1, s8 playerIndex, s8 arg3) {
             player->kartProps &= ~POST_TUMBLE_GAS;
             return;
         }
-        if ((player->lakitu_props & LAKITU_WATER) == LAKITU_WATER) {
+        if ((player->lakituProps & LAKITU_WATER) == LAKITU_WATER) {
             func_80061A34(player, arg1, sp28, playerIndex, arg3);
             player->unk_046 &= ~0x0008;
             player->kartProps &= ~POST_TUMBLE_GAS;
@@ -6437,9 +6437,9 @@ void func_8006CEC0(Player* arg0, s16 arg1, s8 arg2, s8 arg3) {
                 if (((arg0->effects & SQUISH_EFFECT) != SQUISH_EFFECT) &&
                     ((arg0->effects & HIT_BY_GREEN_SHELL_EFFECT) != HIT_BY_GREEN_SHELL_EFFECT) &&
                     ((arg0->effects & EXPLOSION_CRASH_EFFECT) != EXPLOSION_CRASH_EFFECT)) {
-                    if (((arg0->lakitu_props & HELD_BY_LAKITU) != HELD_BY_LAKITU) &&
-                        ((arg0->lakitu_props & FRIGID_EFFECT) != FRIGID_EFFECT) &&
-                        !(arg0->lakitu_props & WENT_OVER_OOB)) {
+                    if (((arg0->lakituProps & HELD_BY_LAKITU) != HELD_BY_LAKITU) &&
+                        ((arg0->lakituProps & FRIGID_EFFECT) != FRIGID_EFFECT) &&
+                        !(arg0->lakituProps & WENT_OVER_OOB)) {
                         func_80060504(arg0, arg1, sp20, arg2, arg3);
                     }
                 }
@@ -6452,9 +6452,9 @@ void func_8006CEC0(Player* arg0, s16 arg1, s8 arg2, s8 arg3) {
                 if (((arg0->type & PLAYER_HUMAN) != 0) && ((arg0->effects & SQUISH_EFFECT) != SQUISH_EFFECT) &&
                     ((arg0->effects & HIT_BY_GREEN_SHELL_EFFECT) != HIT_BY_GREEN_SHELL_EFFECT) &&
                     ((arg0->effects & EXPLOSION_CRASH_EFFECT) != EXPLOSION_CRASH_EFFECT)) {
-                    if (((arg0->lakitu_props & HELD_BY_LAKITU) != HELD_BY_LAKITU) &&
-                        ((arg0->lakitu_props & FRIGID_EFFECT) != FRIGID_EFFECT) &&
-                        !(arg0->lakitu_props & WENT_OVER_OOB)) {
+                    if (((arg0->lakituProps & HELD_BY_LAKITU) != HELD_BY_LAKITU) &&
+                        ((arg0->lakituProps & FRIGID_EFFECT) != FRIGID_EFFECT) &&
+                        !(arg0->lakituProps & WENT_OVER_OOB)) {
                         func_80060504(arg0, arg1, sp20, arg2, arg3);
                     }
                 }
@@ -6483,19 +6483,19 @@ void func_8006D194(Player* player, s8 playerIndex, s8 arg2) {
                 break;
         }
     } else {
-        if ((player->kart_graphics & CRASH) == CRASH) {
+        if ((player->kartGraphics & CRASH) == CRASH) {
             func_800628C0(player, playerIndex, arg2, 0);
         }
-        if ((player->kart_graphics & BOING) == BOING) {
+        if ((player->kartGraphics & BOING) == BOING) {
             func_80062968(player, playerIndex, arg2, 0);
         }
-        if ((player->kart_graphics & EXPLOSION) == EXPLOSION) {
+        if ((player->kartGraphics & EXPLOSION) == EXPLOSION) {
             func_80062914(player, playerIndex, arg2, 0);
         }
-        if ((player->kart_graphics & WHIRRR) == WHIRRR) {
+        if ((player->kartGraphics & WHIRRR) == WHIRRR) {
             func_80062A18(player, playerIndex, arg2, 0);
         }
-        if ((player->kart_graphics & POOMP) == POOMP) {
+        if ((player->kartGraphics & POOMP) == POOMP) {
             func_800629BC(player, playerIndex, arg2, 0);
         }
     }
@@ -6503,7 +6503,7 @@ void func_8006D194(Player* player, s8 playerIndex, s8 arg2) {
         if (player->particles[0x15].type == 5) {
             func_800651F4(player, playerIndex, arg2, 1);
         }
-    } else if ((player->kart_graphics & WHISTLE) == WHISTLE) {
+    } else if ((player->kartGraphics & WHISTLE) == WHISTLE) {
         func_80062AA8(player, playerIndex, arg2, 1);
     }
 }

--- a/src/code_80057C60.c
+++ b/src/code_80057C60.c
@@ -3628,7 +3628,7 @@ void func_800608E0(Player* player, s16 arg1, UNUSED s32 arg2, s8 arg3, UNUSED s8
         var_f0 = 0.0f;
     }
     sp4C = (D_801652A0[arg3] - player->pos[1]) - 3.0f;
-    if ((player->unk_0DE & 1) && (gCurrentCourseId != COURSE_KOOPA_BEACH)) {
+    if ((player->unk_0DE & UNK_0DE_UNDER_OOB_OR_FLUID_LEVEL) && (gCurrentCourseId != COURSE_KOOPA_BEACH)) {
         var_f0 = 2.5f;
         sp4C = (f32) ((f64) (D_801652A0[arg3] - player->pos[1]) + 0.1);
     }
@@ -3711,7 +3711,7 @@ void func_80060F50(Player* player, s16 arg1, UNUSED s32 arg2, s8 arg3, UNUSED s8
     player->particles[arg1].pos[2] = player->pos[2] + (coss(player->particles[arg1].rotation) * -5.8);
     player->particles[arg1].pos[0] = player->pos[0] + (sins(player->particles[arg1].rotation) * -5.8);
     player->particles[arg1].pos[1] = D_801652A0[arg3];
-    player->unk_0DE &= ~0x0008;
+    player->unk_0DE &= ~UNK_0DE_UNDER_OOB_LEVEL;
 }
 
 void func_80061094(Player* player, s16 arg1, UNUSED s32 arg2, UNUSED s8 arg3, UNUSED s8 arg4) {
@@ -4618,7 +4618,7 @@ void func_80064184(Player* player, s16 arg1, s8 arg2, UNUSED s8 arg3) {
     f32 sp3C;
 
     sp40 = D_801652A0[arg2] - player->pos[1] - 3.0f;
-    if (((player->unk_0DE & 1) != 0) && (gCurrentCourseId != COURSE_KOOPA_BEACH)) {
+    if (((player->unk_0DE & UNK_0DE_UNDER_OOB_OR_FLUID_LEVEL) != 0) && (gCurrentCourseId != COURSE_KOOPA_BEACH)) {
         sp40 = D_801652A0[arg2] - player->pos[1] + 0.1;
     }
 
@@ -6263,7 +6263,7 @@ void func_8006C6AC(Player* player, s16 arg1, s8 arg2, s8 arg3) {
                 break;
         }
     } else {
-        if (player->unk_0DE & 1) {
+        if (player->unk_0DE & UNK_0DE_UNDER_OOB_OR_FLUID_LEVEL) {
             func_80060BCC(player, arg1, sp28, arg2_copy, arg3);
         } else if (!(player->effects & MIDAIR_EFFECT) && !(player->effects & HOP_EFFECT)) {
             if (((player->effects & DRIFTING_EFFECT) == DRIFTING_EFFECT) &&
@@ -6424,10 +6424,10 @@ void func_8006CEC0(Player* arg0, s16 arg1, s8 arg2, s8 arg3) {
             func_80061094(arg0, arg1, sp20, arg2, arg3);
             return;
         } else if ((arg0->type & 0x4000) == 0x4000) {
-            if ((arg0->unk_0DE & 8) == 8) {
+            if ((arg0->unk_0DE & UNK_0DE_UNDER_OOB_LEVEL) == UNK_0DE_UNDER_OOB_LEVEL) {
                 func_80060F50(arg0, arg1, sp20, arg2, arg3);
                 return;
-            } else if ((arg0->unk_0DE & 2) || (arg0->unk_0DE & 1)) {
+            } else if ((arg0->unk_0DE & UNK_0DE_PASS_OOB_OR_FLUID_LEVEL) || (arg0->unk_0DE & UNK_0DE_UNDER_OOB_OR_FLUID_LEVEL)) {
                 func_80060B14(arg0, arg1, sp20, arg2, arg3);
                 return;
             }

--- a/src/code_80057C60.c
+++ b/src/code_80057C60.c
@@ -6506,7 +6506,7 @@ void func_8006D194(Player* player, s8 playerIndex, s8 arg2) {
 
 void func_8006D474(Player* player, s8 playerId, s8 screenId) {
     s16 var_s2;
-    if ((player->unk_002 & (8 << (screenId * 4))) == (8 << (screenId * 4))) {
+    if ((player->unk_002 & (SIDE_OF_KART << (screenId * 4))) == (SIDE_OF_KART << (screenId * 4))) {
         for (var_s2 = 0; var_s2 < 10; var_s2++) {
             switch (player->particles[var_s2].type) {
                 case 1:
@@ -6630,7 +6630,7 @@ void func_8006D474(Player* player, s8 playerId, s8 screenId) {
             }
         }
     }
-    if ((gModeSelection == BATTLE) && (player->unk_002 & (2 << (screenId * 4)))) {
+    if ((gModeSelection == BATTLE) && (player->unk_002 & (UNK_002_UNKNOWN_0x2 << (screenId * 4)))) {
         render_remaining_battle_balloons(player, playerId, screenId);
     }
 }
@@ -6639,7 +6639,7 @@ void func_8006DC54(Player* player, s8 playerIndex, s8 screenId) {
     s16 i;
     s32 bitwiseMask;
 
-    bitwiseMask = 8 << (screenId * 4);
+    bitwiseMask = SIDE_OF_KART << (screenId * 4);
     if (bitwiseMask == (player->unk_002 & bitwiseMask)) {
         for (i = 0; i < 10; i++) {
             if (player->particles[i].type == 7) {
@@ -6653,7 +6653,7 @@ void func_8006DD3C(Player* arg0, s8 arg1, s8 arg2) {
     s16 temp_s0;
     s32 temp_v0;
 
-    temp_v0 = 8 << (arg2 * 4);
+    temp_v0 = SIDE_OF_KART << (arg2 * 4);
     if (temp_v0 == (arg0->unk_002 & temp_v0)) {
         for (temp_s0 = 0; temp_s0 < 10; ++temp_s0) {
             temp_v0 = arg0->particles[temp_s0].type;

--- a/src/code_80057C60.c
+++ b/src/code_80057C60.c
@@ -3561,7 +3561,7 @@ void func_80060504(Player* player, s16 arg1, s32 arg2, UNUSED s8 arg3, UNUSED s8
     s32 temp_v0;
     UNUSED s32 test;
 
-    if ((player->kartProps & PRESS_A) == PRESS_A) {
+    if ((player->kartProps & THROTTLE) == THROTTLE) {
         var_v0 = 5;
     } else {
         var_v0 = 0xE;
@@ -3583,7 +3583,7 @@ void func_80060504(Player* player, s16 arg1, s32 arg2, UNUSED s8 arg3, UNUSED s8
         }
     }
     player->particles[arg1].unk_024 = 0.0f;
-    if ((player->kartProps & PRESS_A) == PRESS_A) {
+    if ((player->kartProps & THROTTLE) == THROTTLE) {
         player->particles[arg1].unk_040 = 0;
         if ((player->effects & MUSHROOM_EFFECT) == MUSHROOM_EFFECT) {
             set_particle_colour(&player->particles[arg1], 0x00FFFF00, 0x0080);

--- a/src/code_80057C60.c
+++ b/src/code_80057C60.c
@@ -4282,7 +4282,7 @@ void func_80062F98(Player* player, s16 arg1, s8 arg2, UNUSED s8 arg3) {
     temp_f0 = player->particles[10 + arg1].unk_018 / 10.0f;
     ++player->particles[10 + arg1].timer;
     player->particles[10 + arg1].pos[1] += temp_f0;
-    if ((player->unk_0CA & UNK_0CA_LAKITU_RETRIEVAL) == UNK_0CA_LAKITU_RETRIEVAL) {
+    if ((player->lakitu_props & LAKITU_RETRIEVAL) == LAKITU_RETRIEVAL) {
         player->particles[10 + arg1].pos[1] += (temp_f0 + 0.3);
         if ((player->particles[10 + arg1].timer == 0x10) ||
             ((D_801652A0[arg2] - player->particles[10 + arg1].pos[1]) < 3.0f)) {
@@ -6340,7 +6340,7 @@ void func_8006C9B8(Player* player, s16 arg1, s8 playerIndex, s8 arg3) {
             player->unk_044 &= ~UNK_044_POST_TUMBLE_GAS;
             return;
         }
-        if (((((player->unk_0CA & UNK_0CA_LAKITU_LAVA) == UNK_0CA_LAKITU_LAVA) ||
+        if (((((player->lakitu_props & LAKITU_LAVA) == LAKITU_LAVA) ||
               ((player->unk_0E0 < 2) && (player->effects & EXPLOSION_CRASH_EFFECT))) ||
              ((player->unk_0E0 < 2) && (player->effects & HIT_BY_STAR_EFFECT))) ||
             (player->effects & HIT_BY_GREEN_SHELL_EFFECT)) {
@@ -6349,7 +6349,7 @@ void func_8006C9B8(Player* player, s16 arg1, s8 playerIndex, s8 arg3) {
             player->unk_044 &= ~UNK_044_POST_TUMBLE_GAS;
             return;
         }
-        if ((player->unk_0CA & UNK_0CA_LAKITU_WATER) == UNK_0CA_LAKITU_WATER) {
+        if ((player->lakitu_props & LAKITU_WATER) == LAKITU_WATER) {
             func_80061A34(player, arg1, sp28, playerIndex, arg3);
             player->unk_046 &= ~0x0008;
             player->unk_044 &= ~UNK_044_POST_TUMBLE_GAS;
@@ -6437,7 +6437,7 @@ void func_8006CEC0(Player* arg0, s16 arg1, s8 arg2, s8 arg3) {
                 if (((arg0->effects & SQUISH_EFFECT) != SQUISH_EFFECT) &&
                     ((arg0->effects & HIT_BY_GREEN_SHELL_EFFECT) != HIT_BY_GREEN_SHELL_EFFECT) &&
                     ((arg0->effects & EXPLOSION_CRASH_EFFECT) != EXPLOSION_CRASH_EFFECT)) {
-                    if (((arg0->unk_0CA & UNK_0CA_HELD_BY_LAKITU) != UNK_0CA_HELD_BY_LAKITU) && ((arg0->unk_0CA & UNK_0CA_FRIGID_EFFECT) != UNK_0CA_FRIGID_EFFECT) && !(arg0->unk_0CA & UNK_0CA_WENT_OVER_OOB)) {
+                    if (((arg0->lakitu_props & HELD_BY_LAKITU) != HELD_BY_LAKITU) && ((arg0->lakitu_props & FRIGID_EFFECT) != FRIGID_EFFECT) && !(arg0->lakitu_props & WENT_OVER_OOB)) {
                         func_80060504(arg0, arg1, sp20, arg2, arg3);
                     }
                 }
@@ -6450,7 +6450,7 @@ void func_8006CEC0(Player* arg0, s16 arg1, s8 arg2, s8 arg3) {
             if (((arg0->type & PLAYER_HUMAN) != 0) && ((arg0->effects & SQUISH_EFFECT) != SQUISH_EFFECT) &&
                 ((arg0->effects & HIT_BY_GREEN_SHELL_EFFECT) != HIT_BY_GREEN_SHELL_EFFECT) &&
                 ((arg0->effects & EXPLOSION_CRASH_EFFECT) != EXPLOSION_CRASH_EFFECT)) {
-                if (((arg0->unk_0CA & UNK_0CA_HELD_BY_LAKITU) != UNK_0CA_HELD_BY_LAKITU) && ((arg0->unk_0CA & UNK_0CA_FRIGID_EFFECT) != UNK_0CA_FRIGID_EFFECT) && !(arg0->unk_0CA & UNK_0CA_WENT_OVER_OOB)) {
+                if (((arg0->lakitu_props & HELD_BY_LAKITU) != HELD_BY_LAKITU) && ((arg0->lakitu_props & FRIGID_EFFECT) != FRIGID_EFFECT) && !(arg0->lakitu_props & WENT_OVER_OOB)) {
                     func_80060504(arg0, arg1, sp20, arg2, arg3);
                 }
             }

--- a/src/code_80057C60.c
+++ b/src/code_80057C60.c
@@ -4282,7 +4282,7 @@ void func_80062F98(Player* player, s16 arg1, s8 arg2, UNUSED s8 arg3) {
     temp_f0 = player->particles[10 + arg1].unk_018 / 10.0f;
     ++player->particles[10 + arg1].timer;
     player->particles[10 + arg1].pos[1] += temp_f0;
-    if ((player->unk_0CA & 1) == 1) {
+    if ((player->unk_0CA & UNK_0CA_LAKITU_RETRIEVAL) == UNK_0CA_LAKITU_RETRIEVAL) {
         player->particles[10 + arg1].pos[1] += (temp_f0 + 0.3);
         if ((player->particles[10 + arg1].timer == 0x10) ||
             ((D_801652A0[arg2] - player->particles[10 + arg1].pos[1]) < 3.0f)) {
@@ -6340,7 +6340,7 @@ void func_8006C9B8(Player* player, s16 arg1, s8 playerIndex, s8 arg3) {
             player->unk_044 &= ~UNK_044_POST_TUMBLE_GAS;
             return;
         }
-        if (((((player->unk_0CA & 0x1000) == 0x1000) ||
+        if (((((player->unk_0CA & UNK_0CA_LAKITU_LAVA) == UNK_0CA_LAKITU_LAVA) ||
               ((player->unk_0E0 < 2) && (player->effects & EXPLOSION_CRASH_EFFECT))) ||
              ((player->unk_0E0 < 2) && (player->effects & HIT_BY_STAR_EFFECT))) ||
             (player->effects & HIT_BY_GREEN_SHELL_EFFECT)) {
@@ -6349,7 +6349,7 @@ void func_8006C9B8(Player* player, s16 arg1, s8 playerIndex, s8 arg3) {
             player->unk_044 &= ~UNK_044_POST_TUMBLE_GAS;
             return;
         }
-        if ((player->unk_0CA & 0x2000) == 0x2000) {
+        if ((player->unk_0CA & UNK_0CA_LAKITU_WATER) == UNK_0CA_LAKITU_WATER) {
             func_80061A34(player, arg1, sp28, playerIndex, arg3);
             player->unk_046 &= ~0x0008;
             player->unk_044 &= ~UNK_044_POST_TUMBLE_GAS;
@@ -6437,7 +6437,7 @@ void func_8006CEC0(Player* arg0, s16 arg1, s8 arg2, s8 arg3) {
                 if (((arg0->effects & SQUISH_EFFECT) != SQUISH_EFFECT) &&
                     ((arg0->effects & HIT_BY_GREEN_SHELL_EFFECT) != HIT_BY_GREEN_SHELL_EFFECT) &&
                     ((arg0->effects & EXPLOSION_CRASH_EFFECT) != EXPLOSION_CRASH_EFFECT)) {
-                    if (((arg0->unk_0CA & 2) != 2) && ((arg0->unk_0CA & 0x10) != 0x10) && !(arg0->unk_0CA & 0x100)) {
+                    if (((arg0->unk_0CA & UNK_0CA_HELD_BY_LAKITU) != UNK_0CA_HELD_BY_LAKITU) && ((arg0->unk_0CA & UNK_0CA_FRIGID_EFFECT) != UNK_0CA_FRIGID_EFFECT) && !(arg0->unk_0CA & UNK_0CA_WENT_OVER_OOB)) {
                         func_80060504(arg0, arg1, sp20, arg2, arg3);
                     }
                 }
@@ -6447,14 +6447,14 @@ void func_8006CEC0(Player* arg0, s16 arg1, s8 arg2, s8 arg3) {
             case SCREEN_MODE_2P_SPLITSCREEN_HORIZONTAL:
             case SCREEN_MODE_2P_SPLITSCREEN_VERTICAL:
             case SCREEN_MODE_3P_4P_SPLITSCREEN:
-                if (((arg0->type & 0x4000) != 0) && ((arg0->effects & SQUISH_EFFECT) != SQUISH_EFFECT) &&
-                    ((arg0->effects & HIT_BY_GREEN_SHELL_EFFECT) != HIT_BY_GREEN_SHELL_EFFECT) &&
-                    ((arg0->effects & EXPLOSION_CRASH_EFFECT) != EXPLOSION_CRASH_EFFECT)) {
-                    if (((arg0->unk_0CA & 2) != 2) && ((arg0->unk_0CA & 0x10) != 0x10) && !(arg0->unk_0CA & 0x100)) {
-                        func_80060504(arg0, arg1, sp20, arg2, arg3);
-                    }
+            if (((arg0->type & 0x4000) != 0) && ((arg0->effects & SQUISH_EFFECT) != SQUISH_EFFECT) &&
+                ((arg0->effects & HIT_BY_GREEN_SHELL_EFFECT) != HIT_BY_GREEN_SHELL_EFFECT) &&
+                ((arg0->effects & EXPLOSION_CRASH_EFFECT) != EXPLOSION_CRASH_EFFECT)) {
+                if (((arg0->unk_0CA & UNK_0CA_HELD_BY_LAKITU) != UNK_0CA_HELD_BY_LAKITU) && ((arg0->unk_0CA & UNK_0CA_FRIGID_EFFECT) != UNK_0CA_FRIGID_EFFECT) && !(arg0->unk_0CA & UNK_0CA_WENT_OVER_OOB)) {
+                    func_80060504(arg0, arg1, sp20, arg2, arg3);
                 }
-                break;
+            }
+            break;
         }
     }
 }

--- a/src/code_80057C60.c
+++ b/src/code_80057C60.c
@@ -6423,7 +6423,7 @@ void func_8006CEC0(Player* arg0, s16 arg1, s8 arg2, s8 arg3) {
         } else if (((arg0->effects & LIGHTNING_EFFECT) == LIGHTNING_EFFECT) && (arg0->unk_0B0 < 0x32)) {
             func_80061094(arg0, arg1, sp20, arg2, arg3);
             return;
-        } else if ((arg0->type & 0x4000) == 0x4000) {
+        } else if ((arg0->type & PLAYER_HUMAN) == PLAYER_HUMAN) {
             if ((arg0->unk_0DE & UNK_0DE_UNDER_OOB_LEVEL) == UNK_0DE_UNDER_OOB_LEVEL) {
                 func_80060F50(arg0, arg1, sp20, arg2, arg3);
                 return;
@@ -6447,7 +6447,7 @@ void func_8006CEC0(Player* arg0, s16 arg1, s8 arg2, s8 arg3) {
             case SCREEN_MODE_2P_SPLITSCREEN_HORIZONTAL:
             case SCREEN_MODE_2P_SPLITSCREEN_VERTICAL:
             case SCREEN_MODE_3P_4P_SPLITSCREEN:
-            if (((arg0->type & 0x4000) != 0) && ((arg0->effects & SQUISH_EFFECT) != SQUISH_EFFECT) &&
+            if (((arg0->type & PLAYER_HUMAN) != 0) && ((arg0->effects & SQUISH_EFFECT) != SQUISH_EFFECT) &&
                 ((arg0->effects & HIT_BY_GREEN_SHELL_EFFECT) != HIT_BY_GREEN_SHELL_EFFECT) &&
                 ((arg0->effects & EXPLOSION_CRASH_EFFECT) != EXPLOSION_CRASH_EFFECT)) {
                 if (((arg0->unk_0CA & UNK_0CA_HELD_BY_LAKITU) != UNK_0CA_HELD_BY_LAKITU) && ((arg0->unk_0CA & UNK_0CA_FRIGID_EFFECT) != UNK_0CA_FRIGID_EFFECT) && !(arg0->unk_0CA & UNK_0CA_WENT_OVER_OOB)) {
@@ -6670,7 +6670,7 @@ void func_8006DD3C(Player* arg0, s8 arg1, s8 arg2) {
             }
         }
 
-        if (((arg0->type & 0x4000) == 0x4000) && (arg2 == arg1)) {
+        if (((arg0->type & PLAYER_HUMAN) == PLAYER_HUMAN) && (arg2 == arg1)) {
             switch (arg0->particles[20].type) {
                 case 2:
                     func_80068310(arg0, arg1, arg0->particles[20].scale, arg2, 0);
@@ -6714,11 +6714,11 @@ void func_8006E058(void) {
                 case TIME_TRIALS:
                     func_8006E420(gPlayerOne, 0, 0);
 
-                    if ((gPlayerTwo->type & 0x100) == 0x100) {
+                    if ((gPlayerTwo->type & PLAYER_INVISIBLE_OR_BOMB) == PLAYER_INVISIBLE_OR_BOMB) {
                         func_8006E420(gPlayerTwo, 1, 0);
                     }
 
-                    if ((gPlayerThree->type & 0x100) == 0x100) {
+                    if ((gPlayerThree->type & PLAYER_INVISIBLE_OR_BOMB) == PLAYER_INVISIBLE_OR_BOMB) {
                         func_8006E420(gPlayerThree, 2, 0);
                         break;
                     }

--- a/src/code_80057C60.c
+++ b/src/code_80057C60.c
@@ -4171,7 +4171,7 @@ void func_80062A18(Player* player, s8 arg1, UNUSED s8 arg2, s8 arg3) {
     player->particles[20 + arg1 /* arg1 instead of arg3 */].scale = 0.2f;
     player->particles[20 + arg3].timer = 1;
     player->particles[20 + arg3].rotation = 0;
-    player->unk_0B6 &= ~0x0080;
+    player->unk_0B6 &= ~UNK_0B6_WHIRRR;
     player->particles[20 + arg3].pos[2] = player->pos[2];
     player->particles[20 + arg3].pos[0] = player->pos[0];
     player->particles[20 + arg3].pos[1] = (player->pos[1] + 4.0f);
@@ -4862,7 +4862,7 @@ void func_80064DEC(Player* player, UNUSED s8 arg1, UNUSED s8 arg2, s8 arg3) {
     ++player->particles[20 + arg3].timer;
 
     if (player->particles[20 + arg3].timer == 9) {
-        player->unk_0B6 &= ~0x0040;
+        player->unk_0B6 &= ~UNK_0B6_CRASH;
         player->particles[20 + arg3].IsAlive = 0;
         player->particles[20 + arg3].timer = 0;
         player->particles[20 + arg3].type = 0;
@@ -4884,7 +4884,7 @@ void func_80064EA4(Player* player, UNUSED s8 arg1, UNUSED s8 arg2, s8 arg3) {
     } else {
         player->particles[20 + arg3].scale -= 1.8;
         if (player->particles[20 + arg3].scale <= 0.0f) {
-            player->unk_0B6 &= ~0x1000;
+            player->unk_0B6 &= ~UNK_0B6_EXPLOSION;
             player->particles[20 + arg3].IsAlive = 0;
             player->particles[20 + arg3].timer = 0;
             player->particles[20 + arg3].type = 0;
@@ -4900,7 +4900,7 @@ void func_80064F88(Player* player, UNUSED s8 arg1, UNUSED s8 arg2, s8 arg3) {
         player->particles[20 + arg3].scale = 1.2f;
     }
     if (player->particles[20 + arg3].timer >= 12) {
-        player->unk_0B6 &= ~0x0800;
+        player->unk_0B6 &= ~UNK_0B6_BOING;
         player->particles[20 + arg3].IsAlive = 0;
         player->particles[20 + arg3].timer = 0;
         player->particles[20 + arg3].type = 0;
@@ -4917,7 +4917,7 @@ void func_80065030(Player* player, UNUSED s8 arg1, UNUSED s8 arg2, s8 arg3) {
     }
 
     if (player->particles[20 + arg3].timer >= 12) {
-        player->unk_0B6 &= ~0x0100;
+        player->unk_0B6 &= ~UNK_0B6_POOMP;
         player->particles[20 + arg3].IsAlive = 0;
         player->particles[20 + arg3].timer = 0;
         player->particles[20 + arg3].type = 0;
@@ -4957,7 +4957,7 @@ void func_800651F4(Player* player, UNUSED s8 arg1, UNUSED s8 arg2, s8 arg3) {
     } else {
         player->particles[20 + arg3].scale -= 0.4;
         if (player->particles[20 + arg3].scale <= 0.0f) {
-            player->unk_0B6 &= ~0x0020;
+            player->unk_0B6 &= ~UNK_0B6_WHISTLE;
             player->particles[20 + arg3].IsAlive = 0;
             player->particles[20 + arg3].timer = 0;
             player->particles[20 + arg3].type = 0;
@@ -6479,19 +6479,19 @@ void func_8006D194(Player* player, s8 playerIndex, s8 arg2) {
                 break;
         }
     } else {
-        if ((player->unk_0B6 & 0x40) == 0x40) {
+        if ((player->unk_0B6 & UNK_0B6_CRASH) == UNK_0B6_CRASH) {
             func_800628C0(player, playerIndex, arg2, 0);
         }
-        if ((player->unk_0B6 & 0x800) == 0x800) {
+        if ((player->unk_0B6 & UNK_0B6_BOING) == UNK_0B6_BOING) {
             func_80062968(player, playerIndex, arg2, 0);
         }
-        if ((player->unk_0B6 & 0x1000) == 0x1000) {
+        if ((player->unk_0B6 & UNK_0B6_EXPLOSION) == UNK_0B6_EXPLOSION) {
             func_80062914(player, playerIndex, arg2, 0);
         }
-        if ((player->unk_0B6 & 0x80) == 0x80) {
+        if ((player->unk_0B6 & UNK_0B6_WHIRRR) == UNK_0B6_WHIRRR) {
             func_80062A18(player, playerIndex, arg2, 0);
         }
-        if ((player->unk_0B6 & 0x100) == 0x100) {
+        if ((player->unk_0B6 & UNK_0B6_POOMP) == UNK_0B6_POOMP) {
             func_800629BC(player, playerIndex, arg2, 0);
         }
     }
@@ -6499,7 +6499,7 @@ void func_8006D194(Player* player, s8 playerIndex, s8 arg2) {
         if (player->particles[0x15].type == 5) {
             func_800651F4(player, playerIndex, arg2, 1);
         }
-    } else if ((player->unk_0B6 & 0x20) == 0x20) {
+    } else if ((player->unk_0B6 & UNK_0B6_WHISTLE) == UNK_0B6_WHISTLE) {
         func_80062AA8(player, playerIndex, arg2, 1);
     }
 }

--- a/src/code_80057C60.c
+++ b/src/code_80057C60.c
@@ -3561,7 +3561,7 @@ void func_80060504(Player* player, s16 arg1, s32 arg2, UNUSED s8 arg3, UNUSED s8
     s32 temp_v0;
     UNUSED s32 test;
 
-    if ((player->unk_044 & 0x20) == 0x20) {
+    if ((player->unk_044 & UNK_044_PRESS_A) == UNK_044_PRESS_A) {
         var_v0 = 5;
     } else {
         var_v0 = 0xE;
@@ -3583,7 +3583,7 @@ void func_80060504(Player* player, s16 arg1, s32 arg2, UNUSED s8 arg3, UNUSED s8
         }
     }
     player->particles[arg1].unk_024 = 0.0f;
-    if ((player->unk_044 & 0x20) == 0x20) {
+    if ((player->unk_044 & UNK_044_PRESS_A) == UNK_044_PRESS_A) {
         player->particles[arg1].unk_040 = 0;
         if ((player->effects & MUSHROOM_EFFECT) == MUSHROOM_EFFECT) {
             set_particle_colour(&player->particles[arg1], 0x00FFFF00, 0x0080);
@@ -6417,7 +6417,7 @@ void func_8006CEC0(Player* arg0, s16 arg1, s8 arg2, s8 arg3) {
                 break;
         }
     } else {
-        if ((arg0->unk_044 & 0x200) && (arg0->type & 0x4000)) {
+        if ((arg0->unk_044 & UNK_044_BECOME_INVISIBLE) && (arg0->type & 0x4000)) {
             func_80061224(arg0, arg1, sp20, arg2, arg3);
             return;
         } else if (((arg0->effects & LIGHTNING_EFFECT) == LIGHTNING_EFFECT) && (arg0->unk_0B0 < 0x32)) {

--- a/src/code_80057C60.c
+++ b/src/code_80057C60.c
@@ -3561,7 +3561,7 @@ void func_80060504(Player* player, s16 arg1, s32 arg2, UNUSED s8 arg3, UNUSED s8
     s32 temp_v0;
     UNUSED s32 test;
 
-    if ((player->unk_044 & UNK_044_PRESS_A) == UNK_044_PRESS_A) {
+    if ((player->kartProps & PRESS_A) == PRESS_A) {
         var_v0 = 5;
     } else {
         var_v0 = 0xE;
@@ -3583,7 +3583,7 @@ void func_80060504(Player* player, s16 arg1, s32 arg2, UNUSED s8 arg3, UNUSED s8
         }
     }
     player->particles[arg1].unk_024 = 0.0f;
-    if ((player->unk_044 & UNK_044_PRESS_A) == UNK_044_PRESS_A) {
+    if ((player->kartProps & PRESS_A) == PRESS_A) {
         player->particles[arg1].unk_040 = 0;
         if ((player->effects & MUSHROOM_EFFECT) == MUSHROOM_EFFECT) {
             set_particle_colour(&player->particles[arg1], 0x00FFFF00, 0x0080);
@@ -3743,7 +3743,7 @@ void func_80061224(Player* player, s16 arg1, s32 arg2, s8 arg3, s8 arg4) {
     } else if (player->particles[arg2].timer >= 2) {
         func_80061130(player, arg1, arg2, arg3, arg4);
         if (arg1 == 9) {
-            player->unk_044 &= ~UNK_044_BECOME_INVISIBLE;
+            player->kartProps &= ~BECOME_INVISIBLE;
         }
     }
 }
@@ -3783,7 +3783,7 @@ void func_80061430(Player* player, UNUSED s32 arg1, UNUSED s32 arg2, UNUSED s8 a
         player->particles[0x1E + var_s2].pos[2] = player->pos[2];
         player->particles[0x1E + var_s2].pos[0] = player->pos[0];
     }
-    player->unk_044 &= ~UNK_044_UNUSED_0x1000;
+    player->kartProps &= ~UNUSED_0x1000;
 }
 
 void func_800615AC(Player* player, s16 arg1, UNUSED s32 arg2, UNUSED s8 arg3, UNUSED s8 arg4) {
@@ -4068,42 +4068,42 @@ void func_800624D8(Player* player, UNUSED s32 arg1, UNUSED s32 arg2, UNUSED s8 a
                 }
                 func_80062484(player, &player->particles[0x1E + var_s1], var_s1);
             }
-            player->unk_044 &= ~UNK_044_POST_TUMBLE_GAS;
+            player->kartProps &= ~POST_TUMBLE_GAS;
             break;
         case GRASS:
             for (var_s1 = 0; var_s1 < 10; var_s1++) {
                 func_8005DAD8(&player->particles[0x1E + var_s1], 2, 1, 0x00A8);
                 func_80062484(player, &player->particles[0x1E + var_s1], var_s1);
             }
-            player->unk_044 &= ~UNK_044_POST_TUMBLE_GAS;
+            player->kartProps &= ~POST_TUMBLE_GAS;
             break;
         case SAND_OFFROAD:
             for (var_s1 = 0; var_s1 < 10; var_s1++) {
                 func_8005DAD8(&player->particles[0x1E + var_s1], 2, 1, 0x00A8);
                 func_80062484(player, &player->particles[0x1E + var_s1], var_s1);
             }
-            player->unk_044 &= ~UNK_044_POST_TUMBLE_GAS;
+            player->kartProps &= ~POST_TUMBLE_GAS;
             break;
         case SAND:
             for (var_s1 = 0; var_s1 < 10; var_s1++) {
                 func_8005DAD8(&player->particles[0x1E + var_s1], 3, 1, 0x00A8);
                 func_80062484(player, &player->particles[0x1E + var_s1], var_s1);
             }
-            player->unk_044 &= ~UNK_044_POST_TUMBLE_GAS;
+            player->kartProps &= ~POST_TUMBLE_GAS;
             break;
         case WET_SAND:
             for (var_s1 = 0; var_s1 < 10; var_s1++) {
                 func_8005DAD8(&player->particles[0x1E + var_s1], 4, 1, 0x00A8);
                 func_80062484(player, &player->particles[0x1E + var_s1], var_s1);
             }
-            player->unk_044 &= ~UNK_044_POST_TUMBLE_GAS;
+            player->kartProps &= ~POST_TUMBLE_GAS;
             break;
         case DIRT_OFFROAD:
             for (var_s1 = 0; var_s1 < 10; var_s1++) {
                 func_8005DAD8(&player->particles[0x1E + var_s1], 5, 1, 0x00A8);
                 func_80062484(player, &player->particles[0x1E + var_s1], var_s1);
             }
-            player->unk_044 &= ~UNK_044_POST_TUMBLE_GAS;
+            player->kartProps &= ~POST_TUMBLE_GAS;
             break;
         case SNOW:
         case SNOW_OFFROAD:
@@ -4111,7 +4111,7 @@ void func_800624D8(Player* player, UNUSED s32 arg1, UNUSED s32 arg2, UNUSED s8 a
                 func_8005DAD8(&player->particles[0x1E + var_s1], 6, 1, 0x00A8);
                 func_80062484(player, &player->particles[0x1E + var_s1], var_s1);
             }
-            player->unk_044 &= ~UNK_044_POST_TUMBLE_GAS;
+            player->kartProps &= ~POST_TUMBLE_GAS;
             break;
         case ASPHALT:
         case STONE:
@@ -4120,14 +4120,14 @@ void func_800624D8(Player* player, UNUSED s32 arg1, UNUSED s32 arg2, UNUSED s8 a
                 func_8005DAD8(&player->particles[0x1E + var_s1], 0, 0, 0x00A8);
                 func_80062484(player, &player->particles[0x1E + var_s1], var_s1);
             }
-            player->unk_044 &= ~UNK_044_POST_TUMBLE_GAS;
+            player->kartProps &= ~POST_TUMBLE_GAS;
             break;
         default:
             for (var_s1 = 0; var_s1 < 10; var_s1++) {
                 func_8005DAD8(&player->particles[0x1E + var_s1], 0, 0, 0x00A8);
                 func_80062484(player, &player->particles[0x1E + var_s1], var_s1);
             }
-            player->unk_044 &= ~UNK_044_POST_TUMBLE_GAS;
+            player->kartProps &= ~POST_TUMBLE_GAS;
             break;
     }
 }
@@ -6277,7 +6277,7 @@ void func_8006C6AC(Player* player, s16 arg1, s8 arg2, s8 arg3) {
                 func_8005F90C(player, arg1, sp28, arg2_copy, arg3);
             } else if (((player->effects & EARLY_START_SPINOUT_EFFECT) && !(player->type & PLAYER_START_SEQUENCE)) ||
                        (player->effects & BANANA_NEAR_SPINOUT_EFFECT) || (player->effects & AB_SPIN_EFFECT) ||
-                       (player->unk_044 & UNK_044_DRIVING_SPINOUT)) {
+                       (player->kartProps & DRIVING_SPINOUT)) {
                 func_8005ED48(player, arg1, sp28, arg2_copy, arg3);
             } else {
                 setup_tyre_particles(player, arg1, sp28, arg2_copy, arg3);
@@ -6335,9 +6335,9 @@ void func_8006C9B8(Player* player, s16 arg1, s8 playerIndex, s8 arg3) {
                 break;
         }
     } else {
-        if (player->unk_044 & UNK_044_UNUSED_0x1000) {
+        if (player->kartProps & UNUSED_0x1000) {
             func_80061430(player, arg1, sp28, playerIndex, arg3);
-            player->unk_044 &= ~UNK_044_POST_TUMBLE_GAS;
+            player->kartProps &= ~POST_TUMBLE_GAS;
             return;
         }
         if (((((player->lakitu_props & LAKITU_LAVA) == LAKITU_LAVA) ||
@@ -6346,31 +6346,31 @@ void func_8006C9B8(Player* player, s16 arg1, s8 playerIndex, s8 arg3) {
             (player->effects & HIT_BY_GREEN_SHELL_EFFECT)) {
             func_8006199C(player, arg1, sp28, playerIndex, arg3);
             player->unk_046 &= ~0x0008;
-            player->unk_044 &= ~UNK_044_POST_TUMBLE_GAS;
+            player->kartProps &= ~POST_TUMBLE_GAS;
             return;
         }
         if ((player->lakitu_props & LAKITU_WATER) == LAKITU_WATER) {
             func_80061A34(player, arg1, sp28, playerIndex, arg3);
             player->unk_046 &= ~0x0008;
-            player->unk_044 &= ~UNK_044_POST_TUMBLE_GAS;
+            player->kartProps &= ~POST_TUMBLE_GAS;
             return;
         }
         if ((player->effects & STAR_EFFECT) &&
             ((((s32) gCourseTimer) - gPlayerStarEffectStartTime[playerIndex]) < STAR_EFFECT_DURATION - 1)) {
             func_800615AC(player, arg1, sp28, playerIndex, arg3);
             player->unk_046 &= ~0x0008;
-            player->unk_044 &= ~UNK_044_POST_TUMBLE_GAS;
+            player->kartProps &= ~POST_TUMBLE_GAS;
             return;
         }
         if ((player->unk_046 & 8) == 8) {
             func_800612F8(player, arg1, sp28, playerIndex, arg3);
-            player->unk_044 &= ~UNK_044_POST_TUMBLE_GAS;
+            player->kartProps &= ~POST_TUMBLE_GAS;
             return;
         }
         if (((player->unk_046 & 0x20) == 0x20) && (((player->speed / 18.0f) * 216.0f) >= 20.0f)) {
             func_80061D4C(player, arg1, sp28, playerIndex, arg3);
             player->unk_046 &= ~0x0008;
-            player->unk_044 &= ~UNK_044_POST_TUMBLE_GAS;
+            player->kartProps &= ~POST_TUMBLE_GAS;
             return;
         }
         if ((player->effects & MUSHROOM_EFFECT) && (player->type & PLAYER_HUMAN)) {
@@ -6381,10 +6381,10 @@ void func_8006C9B8(Player* player, s16 arg1, s8 playerIndex, s8 arg3) {
             ((player->type & PLAYER_HUMAN) == PLAYER_HUMAN)) {
             func_80061EF4(player, arg1, sp28, playerIndex, arg3);
             player->unk_046 &= ~0x0008;
-            player->unk_044 &= ~UNK_044_POST_TUMBLE_GAS;
+            player->kartProps &= ~POST_TUMBLE_GAS;
             return;
         }
-        if ((player->unk_044 & UNK_044_POST_TUMBLE_GAS) == UNK_044_POST_TUMBLE_GAS) {
+        if ((player->kartProps & POST_TUMBLE_GAS) == POST_TUMBLE_GAS) {
             func_800624D8(player, arg1, sp28, playerIndex, arg3);
             player->unk_046 &= ~0x0008;
         }
@@ -6417,7 +6417,7 @@ void func_8006CEC0(Player* arg0, s16 arg1, s8 arg2, s8 arg3) {
                 break;
         }
     } else {
-        if ((arg0->unk_044 & UNK_044_BECOME_INVISIBLE) && (arg0->type & UNK_044_DRIVING_SPINOUT)) {
+        if ((arg0->kartProps & BECOME_INVISIBLE) && (arg0->type & DRIVING_SPINOUT)) {
             func_80061224(arg0, arg1, sp20, arg2, arg3);
             return;
         } else if (((arg0->effects & LIGHTNING_EFFECT) == LIGHTNING_EFFECT) && (arg0->unk_0B0 < 0x32)) {

--- a/src/code_80057C60.c
+++ b/src/code_80057C60.c
@@ -3743,7 +3743,7 @@ void func_80061224(Player* player, s16 arg1, s32 arg2, s8 arg3, s8 arg4) {
     } else if (player->particles[arg2].timer >= 2) {
         func_80061130(player, arg1, arg2, arg3, arg4);
         if (arg1 == 9) {
-            player->unk_044 &= ~0x0200;
+            player->unk_044 &= ~UNK_044_BECOME_INVISIBLE;
         }
     }
 }
@@ -3783,7 +3783,7 @@ void func_80061430(Player* player, UNUSED s32 arg1, UNUSED s32 arg2, UNUSED s8 a
         player->particles[0x1E + var_s2].pos[2] = player->pos[2];
         player->particles[0x1E + var_s2].pos[0] = player->pos[0];
     }
-    player->unk_044 &= ~0x1000;
+    player->unk_044 &= ~UNK_044_UNUSED_0x1000;
 }
 
 void func_800615AC(Player* player, s16 arg1, UNUSED s32 arg2, UNUSED s8 arg3, UNUSED s8 arg4) {
@@ -4068,42 +4068,42 @@ void func_800624D8(Player* player, UNUSED s32 arg1, UNUSED s32 arg2, UNUSED s8 a
                 }
                 func_80062484(player, &player->particles[0x1E + var_s1], var_s1);
             }
-            player->unk_044 &= ~0x0100;
+            player->unk_044 &= ~UNK_044_POST_TUMBLE_GAS;
             break;
         case GRASS:
             for (var_s1 = 0; var_s1 < 10; var_s1++) {
                 func_8005DAD8(&player->particles[0x1E + var_s1], 2, 1, 0x00A8);
                 func_80062484(player, &player->particles[0x1E + var_s1], var_s1);
             }
-            player->unk_044 &= ~0x0100;
+            player->unk_044 &= ~UNK_044_POST_TUMBLE_GAS;
             break;
         case SAND_OFFROAD:
             for (var_s1 = 0; var_s1 < 10; var_s1++) {
                 func_8005DAD8(&player->particles[0x1E + var_s1], 2, 1, 0x00A8);
                 func_80062484(player, &player->particles[0x1E + var_s1], var_s1);
             }
-            player->unk_044 &= ~0x0100;
+            player->unk_044 &= ~UNK_044_POST_TUMBLE_GAS;
             break;
         case SAND:
             for (var_s1 = 0; var_s1 < 10; var_s1++) {
                 func_8005DAD8(&player->particles[0x1E + var_s1], 3, 1, 0x00A8);
                 func_80062484(player, &player->particles[0x1E + var_s1], var_s1);
             }
-            player->unk_044 &= ~0x0100;
+            player->unk_044 &= ~UNK_044_POST_TUMBLE_GAS;
             break;
         case WET_SAND:
             for (var_s1 = 0; var_s1 < 10; var_s1++) {
                 func_8005DAD8(&player->particles[0x1E + var_s1], 4, 1, 0x00A8);
                 func_80062484(player, &player->particles[0x1E + var_s1], var_s1);
             }
-            player->unk_044 &= ~0x0100;
+            player->unk_044 &= ~UNK_044_POST_TUMBLE_GAS;
             break;
         case DIRT_OFFROAD:
             for (var_s1 = 0; var_s1 < 10; var_s1++) {
                 func_8005DAD8(&player->particles[0x1E + var_s1], 5, 1, 0x00A8);
                 func_80062484(player, &player->particles[0x1E + var_s1], var_s1);
             }
-            player->unk_044 &= ~0x0100;
+            player->unk_044 &= ~UNK_044_POST_TUMBLE_GAS;
             break;
         case SNOW:
         case SNOW_OFFROAD:
@@ -4111,7 +4111,7 @@ void func_800624D8(Player* player, UNUSED s32 arg1, UNUSED s32 arg2, UNUSED s8 a
                 func_8005DAD8(&player->particles[0x1E + var_s1], 6, 1, 0x00A8);
                 func_80062484(player, &player->particles[0x1E + var_s1], var_s1);
             }
-            player->unk_044 &= ~0x0100;
+            player->unk_044 &= ~UNK_044_POST_TUMBLE_GAS;
             break;
         case ASPHALT:
         case STONE:
@@ -4120,14 +4120,14 @@ void func_800624D8(Player* player, UNUSED s32 arg1, UNUSED s32 arg2, UNUSED s8 a
                 func_8005DAD8(&player->particles[0x1E + var_s1], 0, 0, 0x00A8);
                 func_80062484(player, &player->particles[0x1E + var_s1], var_s1);
             }
-            player->unk_044 &= ~0x0100;
+            player->unk_044 &= ~UNK_044_POST_TUMBLE_GAS;
             break;
         default:
             for (var_s1 = 0; var_s1 < 10; var_s1++) {
                 func_8005DAD8(&player->particles[0x1E + var_s1], 0, 0, 0x00A8);
                 func_80062484(player, &player->particles[0x1E + var_s1], var_s1);
             }
-            player->unk_044 &= ~0x0100;
+            player->unk_044 &= ~UNK_044_POST_TUMBLE_GAS;
             break;
     }
 }
@@ -6277,7 +6277,7 @@ void func_8006C6AC(Player* player, s16 arg1, s8 arg2, s8 arg3) {
                 func_8005F90C(player, arg1, sp28, arg2_copy, arg3);
             } else if (((player->effects & EARLY_START_SPINOUT_EFFECT) && !(player->type & PLAYER_START_SEQUENCE)) ||
                        (player->effects & BANANA_NEAR_SPINOUT_EFFECT) || (player->effects & AB_SPIN_EFFECT) ||
-                       (player->unk_044 & 0x4000)) {
+                       (player->unk_044 & UNK_044_DRIVING_SPINOUT)) {
                 func_8005ED48(player, arg1, sp28, arg2_copy, arg3);
             } else {
                 setup_tyre_particles(player, arg1, sp28, arg2_copy, arg3);
@@ -6335,9 +6335,9 @@ void func_8006C9B8(Player* player, s16 arg1, s8 playerIndex, s8 arg3) {
                 break;
         }
     } else {
-        if (player->unk_044 & 0x1000) {
+        if (player->unk_044 & UNK_044_UNUSED_0x1000) {
             func_80061430(player, arg1, sp28, playerIndex, arg3);
-            player->unk_044 &= ~0x0100;
+            player->unk_044 &= ~UNK_044_POST_TUMBLE_GAS;
             return;
         }
         if (((((player->unk_0CA & 0x1000) == 0x1000) ||
@@ -6346,31 +6346,31 @@ void func_8006C9B8(Player* player, s16 arg1, s8 playerIndex, s8 arg3) {
             (player->effects & HIT_BY_GREEN_SHELL_EFFECT)) {
             func_8006199C(player, arg1, sp28, playerIndex, arg3);
             player->unk_046 &= ~0x0008;
-            player->unk_044 &= ~0x0100;
+            player->unk_044 &= ~UNK_044_POST_TUMBLE_GAS;
             return;
         }
         if ((player->unk_0CA & 0x2000) == 0x2000) {
             func_80061A34(player, arg1, sp28, playerIndex, arg3);
             player->unk_046 &= ~0x0008;
-            player->unk_044 &= ~0x0100;
+            player->unk_044 &= ~UNK_044_POST_TUMBLE_GAS;
             return;
         }
         if ((player->effects & STAR_EFFECT) &&
             ((((s32) gCourseTimer) - gPlayerStarEffectStartTime[playerIndex]) < STAR_EFFECT_DURATION - 1)) {
             func_800615AC(player, arg1, sp28, playerIndex, arg3);
             player->unk_046 &= ~0x0008;
-            player->unk_044 &= ~0x0100;
+            player->unk_044 &= ~UNK_044_POST_TUMBLE_GAS;
             return;
         }
         if ((player->unk_046 & 8) == 8) {
             func_800612F8(player, arg1, sp28, playerIndex, arg3);
-            player->unk_044 &= ~0x0100;
+            player->unk_044 &= ~UNK_044_POST_TUMBLE_GAS;
             return;
         }
         if (((player->unk_046 & 0x20) == 0x20) && (((player->speed / 18.0f) * 216.0f) >= 20.0f)) {
             func_80061D4C(player, arg1, sp28, playerIndex, arg3);
             player->unk_046 &= ~0x0008;
-            player->unk_044 &= ~0x0100;
+            player->unk_044 &= ~UNK_044_POST_TUMBLE_GAS;
             return;
         }
         if ((player->effects & MUSHROOM_EFFECT) && (player->type & PLAYER_HUMAN)) {
@@ -6381,10 +6381,10 @@ void func_8006C9B8(Player* player, s16 arg1, s8 playerIndex, s8 arg3) {
             ((player->type & PLAYER_HUMAN) == PLAYER_HUMAN)) {
             func_80061EF4(player, arg1, sp28, playerIndex, arg3);
             player->unk_046 &= ~0x0008;
-            player->unk_044 &= ~0x0100;
+            player->unk_044 &= ~UNK_044_POST_TUMBLE_GAS;
             return;
         }
-        if ((player->unk_044 & 0x100) == 0x100) {
+        if ((player->unk_044 & UNK_044_POST_TUMBLE_GAS) == UNK_044_POST_TUMBLE_GAS) {
             func_800624D8(player, arg1, sp28, playerIndex, arg3);
             player->unk_046 &= ~0x0008;
         }
@@ -6417,7 +6417,7 @@ void func_8006CEC0(Player* arg0, s16 arg1, s8 arg2, s8 arg3) {
                 break;
         }
     } else {
-        if ((arg0->unk_044 & UNK_044_BECOME_INVISIBLE) && (arg0->type & 0x4000)) {
+        if ((arg0->unk_044 & UNK_044_BECOME_INVISIBLE) && (arg0->type & UNK_044_DRIVING_SPINOUT)) {
             func_80061224(arg0, arg1, sp20, arg2, arg3);
             return;
         } else if (((arg0->effects & LIGHTNING_EFFECT) == LIGHTNING_EFFECT) && (arg0->unk_0B0 < 0x32)) {

--- a/src/cpu_vehicles_camera_path.c
+++ b/src/cpu_vehicles_camera_path.c
@@ -745,7 +745,7 @@ void set_places(void) {
     }
 
     for (playerId = 0; playerId < numPlayer - 1; playerId++) {
-        if ((gPlayers[gGPCurrentRacePlayerIdByRank[playerId]].type & 0x800)) {
+        if ((gPlayers[gGPCurrentRacePlayerIdByRank[playerId]].type & PLAYER_CINEMATIC_MODE)) {
             continue;
         }
 
@@ -984,7 +984,7 @@ bool func_800088D8(s32 playerId, s16 arg1, s16 arg2) {
         return 1;
     }
     player = &gPlayers[playerId];
-    if (player->type & 0x4000) {
+    if (player->type & PLAYER_HUMAN) {
         return 1;
     }
 
@@ -4538,26 +4538,26 @@ void func_8001C14C(void) {
 
         temp_s0 = &gPlayerOne[playerId];
         update_player(playerId);
-        if (!(temp_s0->type & 0x2000)) {
+        if (!(temp_s0->type & PLAYER_START_SEQUENCE)) {
             temp_f0 = D_80163418[playerId] - temp_s0->pos[0];
             temp_f2 = D_80163438[playerId] - temp_s0->pos[2];
             if ((f64) ((temp_f0 * temp_f0) + (temp_f2 * temp_f2)) < 1.0) {
                 if (playerId != 3) {
                     if (1) {}
                     // Why oh why is a ternary required here? Who does that?
-                    (D_8016347C == 0) ? (temp_s0->type |= 0x2000) : (temp_s0->type &= ~0x2000);
-                    if ((gPlayerOne->type & 0x2000) && (gPlayerTwo->type & 0x2000) && (gPlayerThree->type & 0x2000)) {
+                    (D_8016347C == 0) ? (temp_s0->type |= PLAYER_START_SEQUENCE) : (temp_s0->type &= ~PLAYER_START_SEQUENCE);
+                    if ((gPlayerOne->type & PLAYER_START_SEQUENCE) && (gPlayerTwo->type & PLAYER_START_SEQUENCE) && (gPlayerThree->type & PLAYER_START_SEQUENCE)) {
                         D_8016347C = 1;
                         D_80163480 = 0;
                     }
                 } else if (D_8016347E == 0) {
                     if (!(temp_s0->effects & EXPLOSION_CRASH_EFFECT)) {
-                        temp_s0->type |= 0x2000;
+                        temp_s0->type |= PLAYER_START_SEQUENCE;
                     }
                     D_8016347E = 1;
                     D_80163484 = 0;
                 } else if (!(temp_s0->effects & EXPLOSION_CRASH_EFFECT)) {
-                    temp_s0->type |= 0x2000;
+                    temp_s0->type |= PLAYER_START_SEQUENCE;
                 }
             }
         }

--- a/src/cpu_vehicles_camera_path.c
+++ b/src/cpu_vehicles_camera_path.c
@@ -1361,7 +1361,8 @@ void play_cpu_sound_effect(s32 arg0, Player* player) {
     }
     if (D_801633B0[arg0] >= 0xB) {
         if ((player->triggers & VERTICAL_TUMBLE_TRIGGER) || (player->triggers & HIT_BY_STAR_TRIGGER) ||
-            (player->triggers & HIGH_TUMBLE_TRIGGER) || (player->triggers & LOW_TUMBLE_TRIGGER) || (player->effects & SQUISH_EFFECT)) {
+            (player->triggers & HIGH_TUMBLE_TRIGGER) || (player->triggers & LOW_TUMBLE_TRIGGER) ||
+            (player->effects & SQUISH_EFFECT)) {
             func_800C92CC(arg0, SOUND_ARG_LOAD(0x29, 0x00, 0x80, 0x0B));
             D_801633B0[arg0] = 0;
         }
@@ -3794,7 +3795,8 @@ void func_8001A588(UNUSED u16* localD_80152300, Camera* camera, Player* player, 
                         if (playerId >= 8) {
                             playerId = 1;
                         }
-                        if ((!(gPlayers[playerId].lakitu_props & HELD_BY_LAKITU) && !(gPlayers[playerId].lakitu_props & LAKITU_SCENE))) {
+                        if ((!(gPlayers[playerId].lakitu_props & HELD_BY_LAKITU) &&
+                             !(gPlayers[playerId].lakitu_props & LAKITU_SCENE))) {
                             break;
                         }
                     }
@@ -4545,8 +4547,10 @@ void func_8001C14C(void) {
                 if (playerId != 3) {
                     if (1) {}
                     // Why oh why is a ternary required here? Who does that?
-                    (D_8016347C == 0) ? (temp_s0->type |= PLAYER_START_SEQUENCE) : (temp_s0->type &= ~PLAYER_START_SEQUENCE);
-                    if ((gPlayerOne->type & PLAYER_START_SEQUENCE) && (gPlayerTwo->type & PLAYER_START_SEQUENCE) && (gPlayerThree->type & PLAYER_START_SEQUENCE)) {
+                    (D_8016347C == 0) ? (temp_s0->type |= PLAYER_START_SEQUENCE)
+                                      : (temp_s0->type &= ~PLAYER_START_SEQUENCE);
+                    if ((gPlayerOne->type & PLAYER_START_SEQUENCE) && (gPlayerTwo->type & PLAYER_START_SEQUENCE) &&
+                        (gPlayerThree->type & PLAYER_START_SEQUENCE)) {
                         D_8016347C = 1;
                         D_80163480 = 0;
                     }

--- a/src/cpu_vehicles_camera_path.c
+++ b/src/cpu_vehicles_camera_path.c
@@ -1435,7 +1435,7 @@ void update_player(s32 playerId) {
         if (gCourseMaxZ < player->pos[2]) {            D_801633E0[playerId] = 4;        }
         // clang-format on
 
-        if (!(player->unk_0CA & 2) && !(player->unk_0CA & 8)) {
+        if (!(player->unk_0CA & UNK_0CA_HELD_BY_LAKITU) && !(player->unk_0CA & UNK_0CA_LAKITU_SCENE)) {
             gPlayerPathIndex = gPathIndexByPlayerId[playerId];
             set_current_path(gPlayerPathIndex);
             switch (gCurrentCourseId) { /* irregular */
@@ -3794,7 +3794,7 @@ void func_8001A588(UNUSED u16* localD_80152300, Camera* camera, Player* player, 
                         if (playerId >= 8) {
                             playerId = 1;
                         }
-                        if ((!(gPlayers[playerId].unk_0CA & 2) && !(gPlayers[playerId].unk_0CA & 8))) {
+                        if ((!(gPlayers[playerId].unk_0CA & UNK_0CA_HELD_BY_LAKITU) && !(gPlayers[playerId].unk_0CA & UNK_0CA_LAKITU_SCENE))) {
                             break;
                         }
                     }

--- a/src/cpu_vehicles_camera_path.c
+++ b/src/cpu_vehicles_camera_path.c
@@ -1435,7 +1435,7 @@ void update_player(s32 playerId) {
         if (gCourseMaxZ < player->pos[2]) {            D_801633E0[playerId] = 4;        }
         // clang-format on
 
-        if (!(player->unk_0CA & UNK_0CA_HELD_BY_LAKITU) && !(player->unk_0CA & UNK_0CA_LAKITU_SCENE)) {
+        if (!(player->lakitu_props & HELD_BY_LAKITU) && !(player->lakitu_props & LAKITU_SCENE)) {
             gPlayerPathIndex = gPathIndexByPlayerId[playerId];
             set_current_path(gPlayerPathIndex);
             switch (gCurrentCourseId) { /* irregular */
@@ -3794,7 +3794,7 @@ void func_8001A588(UNUSED u16* localD_80152300, Camera* camera, Player* player, 
                         if (playerId >= 8) {
                             playerId = 1;
                         }
-                        if ((!(gPlayers[playerId].unk_0CA & UNK_0CA_HELD_BY_LAKITU) && !(gPlayers[playerId].unk_0CA & UNK_0CA_LAKITU_SCENE))) {
+                        if ((!(gPlayers[playerId].lakitu_props & HELD_BY_LAKITU) && !(gPlayers[playerId].lakitu_props & LAKITU_SCENE))) {
                             break;
                         }
                     }

--- a/src/cpu_vehicles_camera_path.c
+++ b/src/cpu_vehicles_camera_path.c
@@ -1457,7 +1457,7 @@ void update_player(s32 playerId) {
             }
             if (player->type & PLAYER_CINEMATIC_MODE) {
                 player->effects &= ~REVERSE_EFFECT;
-                player->unk_044 &= ~UNK_044_BACK_UP;
+                player->kartProps &= ~BACK_UP;
             }
             update_player_path_completion(playerId, player);
             if ((gCurrentCourseId != COURSE_AWARD_CEREMONY) && ((D_80163240[playerId] == 1) || (playerId == 0))) {

--- a/src/cpu_vehicles_camera_path.c
+++ b/src/cpu_vehicles_camera_path.c
@@ -1436,7 +1436,7 @@ void update_player(s32 playerId) {
         if (gCourseMaxZ < player->pos[2]) {            D_801633E0[playerId] = 4;        }
         // clang-format on
 
-        if (!(player->lakitu_props & HELD_BY_LAKITU) && !(player->lakitu_props & LAKITU_SCENE)) {
+        if (!(player->lakituProps & HELD_BY_LAKITU) && !(player->lakituProps & LAKITU_SCENE)) {
             gPlayerPathIndex = gPathIndexByPlayerId[playerId];
             set_current_path(gPlayerPathIndex);
             switch (gCurrentCourseId) { /* irregular */
@@ -3795,8 +3795,8 @@ void func_8001A588(UNUSED u16* localD_80152300, Camera* camera, Player* player, 
                         if (playerId >= 8) {
                             playerId = 1;
                         }
-                        if ((!(gPlayers[playerId].lakitu_props & HELD_BY_LAKITU) &&
-                             !(gPlayers[playerId].lakitu_props & LAKITU_SCENE))) {
+                        if ((!(gPlayers[playerId].lakituProps & HELD_BY_LAKITU) &&
+                             !(gPlayers[playerId].lakituProps & LAKITU_SCENE))) {
                             break;
                         }
                     }

--- a/src/cpu_vehicles_camera_path.c
+++ b/src/cpu_vehicles_camera_path.c
@@ -1457,7 +1457,7 @@ void update_player(s32 playerId) {
             }
             if (player->type & PLAYER_CINEMATIC_MODE) {
                 player->effects &= ~REVERSE_EFFECT;
-                player->unk_044 &= ~0x0001;
+                player->unk_044 &= ~UNK_044_BACK_UP;
             }
             update_player_path_completion(playerId, player);
             if ((gCurrentCourseId != COURSE_AWARD_CEREMONY) && ((D_80163240[playerId] == 1) || (playerId == 0))) {

--- a/src/cpu_vehicles_camera_path/bomb_kart.inc.c
+++ b/src/cpu_vehicles_camera_path/bomb_kart.inc.c
@@ -140,7 +140,7 @@ void func_8000DF8C(s32 bombKartId) {
                         var_s1 = 0;
                         sp7E = 4;
                         var_v0->triggers |= VERTICAL_TUMBLE_TRIGGER;
-                        var_v0->type &= ~0x2000;
+                        var_v0->type &= ~PLAYER_START_SEQUENCE;
                     }
                 }
             } else {

--- a/src/cpu_vehicles_camera_path/cpu_speed_control.inc.c
+++ b/src/cpu_vehicles_camera_path/cpu_speed_control.inc.c
@@ -133,8 +133,9 @@ void regulate_cpu_speed(s32 playerId, f32 targetSpeed, Player* player) {
     s32 var_a1;
 
     speed = player->speed;
-    if (!(player->effects & BANANA_SPINOUT_EFFECT) && !(player->effects & DRIVING_SPINOUT_EFFECT) && !(player->effects & LIGHTNING_STRIKE_EFFECT) &&
-        !(player->triggers & VERTICAL_TUMBLE_TRIGGER) && !(player->triggers & HIT_BY_STAR_TRIGGER) && !(player->triggers & HIGH_TUMBLE_TRIGGER) &&
+    if (!(player->effects & BANANA_SPINOUT_EFFECT) && !(player->effects & DRIVING_SPINOUT_EFFECT) &&
+        !(player->effects & LIGHTNING_STRIKE_EFFECT) && !(player->triggers & VERTICAL_TUMBLE_TRIGGER) &&
+        !(player->triggers & HIT_BY_STAR_TRIGGER) && !(player->triggers & HIGH_TUMBLE_TRIGGER) &&
         !(player->triggers & LOW_TUMBLE_TRIGGER)) {
         if (gCurrentCourseId == COURSE_AWARD_CEREMONY) {
             func_80007FA4(playerId, player, speed);

--- a/src/cpu_vehicles_camera_path/path_utils.inc.c
+++ b/src/cpu_vehicles_camera_path/path_utils.inc.c
@@ -458,12 +458,12 @@ s16 update_player_path(f32 posX, f32 posY, f32 posZ, s16 pathPointIndex, Player*
         }
     } else { // AI or special case player handling
         if (D_801631E0[playerId] == true) {
-            if (player->unk_0CA & 1) {
+            if (player->unk_0CA & UNK_0CA_LAKITU_RETRIEVAL) {
                 temp_v1 = &gTrackPaths[pathIndex][pathPointIndex];
                 player->pos[0] = (f32) temp_v1->posX;
                 player->pos[1] = (f32) temp_v1->posY;
                 player->pos[2] = (f32) temp_v1->posZ;
-                player->unk_0CA &= ~0x0001;
+                player->unk_0CA &= ~UNK_0CA_LAKITU_RETRIEVAL;
                 return pathPointIndex;
             }
             if (playerId == ((s32) D_80163488 % 8)) {

--- a/src/cpu_vehicles_camera_path/path_utils.inc.c
+++ b/src/cpu_vehicles_camera_path/path_utils.inc.c
@@ -458,12 +458,12 @@ s16 update_player_path(f32 posX, f32 posY, f32 posZ, s16 pathPointIndex, Player*
         }
     } else { // AI or special case player handling
         if (D_801631E0[playerId] == true) {
-            if (player->lakitu_props & LAKITU_RETRIEVAL) {
+            if (player->lakituProps & LAKITU_RETRIEVAL) {
                 temp_v1 = &gTrackPaths[pathIndex][pathPointIndex];
                 player->pos[0] = (f32) temp_v1->posX;
                 player->pos[1] = (f32) temp_v1->posY;
                 player->pos[2] = (f32) temp_v1->posZ;
-                player->lakitu_props &= ~LAKITU_RETRIEVAL;
+                player->lakituProps &= ~LAKITU_RETRIEVAL;
                 return pathPointIndex;
             }
             if (playerId == ((s32) D_80163488 % 8)) {

--- a/src/cpu_vehicles_camera_path/path_utils.inc.c
+++ b/src/cpu_vehicles_camera_path/path_utils.inc.c
@@ -458,12 +458,12 @@ s16 update_player_path(f32 posX, f32 posY, f32 posZ, s16 pathPointIndex, Player*
         }
     } else { // AI or special case player handling
         if (D_801631E0[playerId] == true) {
-            if (player->unk_0CA & UNK_0CA_LAKITU_RETRIEVAL) {
+            if (player->lakitu_props & LAKITU_RETRIEVAL) {
                 temp_v1 = &gTrackPaths[pathIndex][pathPointIndex];
                 player->pos[0] = (f32) temp_v1->posX;
                 player->pos[1] = (f32) temp_v1->posY;
                 player->pos[2] = (f32) temp_v1->posZ;
-                player->unk_0CA &= ~UNK_0CA_LAKITU_RETRIEVAL;
+                player->lakitu_props &= ~LAKITU_RETRIEVAL;
                 return pathPointIndex;
             }
             if (playerId == ((s32) D_80163488 % 8)) {

--- a/src/effects.c
+++ b/src/effects.c
@@ -137,7 +137,7 @@ void func_8008C310(Player* player) {
     // The << 9 is a hacky way to check for VERTICAL_TUMBLE_TRIGGER
     if ((player->triggers & HIGH_TUMBLE_TRIGGER) || (player->triggers & LOW_TUMBLE_TRIGGER) ||
         ((player->triggers << 9) < 0) || (player->triggers & HIT_BY_STAR_TRIGGER)) {
-        player->kart_graphics = ((u16) player->kart_graphics | EXPLOSION);
+        player->kartGraphics = ((u16) player->kartGraphics | EXPLOSION);
     }
 }
 
@@ -269,7 +269,7 @@ void func_8008C73C(Player* player, s8 playerIndex) {
             player->effects |= BANANA_SPINOUT_EFFECT;
         }
 
-        player->kart_graphics |= WHIRRR;
+        player->kartGraphics |= WHIRRR;
         // clang-format off
         player->unk_0C0 = 0; player->unk_07C = 0; player->unk_078 = 0; player->unk_0AE = player->rotation[1]; player->unk_0B2 = 2;
         // clang-format on
@@ -313,7 +313,7 @@ void func_8008C8C4(Player* player, s8 playerId) {
         player->currentSpeed = (f32) (player->currentSpeed + 100.0f);
     }
     if ((gModeSelection == VERSUS) && ((player->type & PLAYER_CPU) == PLAYER_CPU) && (!gDemoMode) &&
-        ((player->lakitu_props & HELD_BY_LAKITU) == 0) && (gGPCurrentRaceRankByPlayerId[playerId] != 0)) {
+        ((player->lakituProps & HELD_BY_LAKITU) == 0) && (gGPCurrentRaceRankByPlayerId[playerId] != 0)) {
         player->triggers = (s32) (player->triggers | VERTICAL_TUMBLE_TRIGGER);
     }
 }
@@ -414,7 +414,7 @@ void func_8008CEB0(Player* player, s8 playerIndex) {
                 func_8008C73C(player, playerIndex);
                 var_v1 = 0;
             } else {
-                player->kart_graphics |= WHISTLE;
+                player->kartGraphics |= WHISTLE;
                 player->effects &= ~BANANA_SPINOUT_SAVE_EFFECT;
                 if ((player->type & PLAYER_HUMAN) == PLAYER_HUMAN) {
                     func_800C90F4(playerIndex, (player->characterId * 0x10) + 0x29008008);
@@ -479,7 +479,7 @@ void func_8008D170(Player* player, s8 playerIndex) {
                 func_8008C73C(player, playerIndex);
                 var_v1 = 0;
             } else {
-                player->kart_graphics |= WHISTLE;
+                player->kartGraphics |= WHISTLE;
                 player->effects &= ~BANANA_SPINOUT_SAVE_EFFECT;
                 if ((player->type & PLAYER_HUMAN) == PLAYER_HUMAN) {
                     func_800C90F4(playerIndex, (player->characterId * 0x10) + 0x29008008);
@@ -1031,7 +1031,7 @@ void trigger_vertical_tumble(Player* player, s8 playerIndex) {
     }
 
     player->triggers &= ~(VERTICAL_TUMBLE_TRIGGER | HIT_PADDLE_BOAT_TRIGGER);
-    player->kart_graphics |= CRASH;
+    player->kartGraphics |= CRASH;
     gTimerBoostTripleACombo[playerIndex] = 0;
     gIsPlayerTripleAButtonCombo[playerIndex] = false;
     gCountASwitch[playerIndex] = 0;
@@ -1131,7 +1131,7 @@ void trigger_high_tumble(Player* player, s8 playerIndex) {
     }
 
     player->effects |= HIT_BY_STAR_EFFECT;
-    player->kart_graphics |= CRASH;
+    player->kartGraphics |= CRASH;
     player->triggers &= ~(HIT_BY_STAR_TRIGGER | HIGH_TUMBLE_TRIGGER);
 
     gTimerBoostTripleACombo[playerIndex] = 0;
@@ -1346,7 +1346,7 @@ void func_8008F494(Player* player, s8 playerIndex) {
     player->unk_042 = 0;
 
     if (((player->type & PLAYER_HUMAN) != 0) && ((player->type & PLAYER_INVISIBLE_OR_BOMB) == 0) &&
-        ((player->lakitu_props & HELD_BY_LAKITU) == 0) && ((player->oobProps & UNDER_OOB_OR_FLUID_LEVEL) == 0) &&
+        ((player->lakituProps & HELD_BY_LAKITU) == 0) && ((player->oobProps & UNDER_OOB_OR_FLUID_LEVEL) == 0) &&
         ((player->oobProps & PASS_OOB_OR_FLUID_LEVEL) == 0)) {
         func_800C90F4(playerIndex, (player->characterId * 0x10) + 0x29008004);
     }
@@ -1774,7 +1774,7 @@ void func_80090778(Player* player) {
     player->unk_078 = 0;
     player->unk_07C = 0;
     player->unk_0C0 = 0;
-    player->lakitu_props |= LAKITU_SCENE;
+    player->lakituProps |= LAKITU_SCENE;
     player->effects &= ~DRIFTING_EFFECT;
     player->unk_222 = 0;
     player->unk_08C = 0.0f;
@@ -1807,25 +1807,25 @@ void func_80090868(Player* player) {
     player->unk_08C = 0.0f;
     playerIndex = get_player_index_for_player(player);
 
-    if ((player->lakitu_props & HELD_BY_LAKITU) != HELD_BY_LAKITU) {
+    if ((player->lakituProps & HELD_BY_LAKITU) != HELD_BY_LAKITU) {
         player->unk_D98 = 1;
         player->unk_D9C = 0.0f;
         player->unk_DA0 = 0.5f;
         course_update_path_point(player, playerIndex);
         player->unk_222 = 0;
-        player->lakitu_props |= HELD_BY_LAKITU;
+        player->lakituProps |= HELD_BY_LAKITU;
         player->unk_0C8 = 0;
         if ((player->oobProps & UNDER_OOB_OR_FLUID_LEVEL) == UNDER_OOB_OR_FLUID_LEVEL) {
             if ((gCurrentCourseId == COURSE_BOWSER_CASTLE) || (gCurrentCourseId == COURSE_BIG_DONUT)) {
-                player->lakitu_props |= LAKITU_LAVA;
+                player->lakituProps |= LAKITU_LAVA;
             } else {
-                player->lakitu_props |= LAKITU_WATER;
+                player->lakituProps |= LAKITU_WATER;
             }
             // removing the water effect for Sherbet Land makes sense. Perhaps rainbow road and skyscraper
             // had lava instead of an abyss initially?
             if ((gCurrentCourseId == COURSE_SHERBET_LAND) || (gCurrentCourseId == COURSE_SKYSCRAPER) ||
                 (gCurrentCourseId == COURSE_RAINBOW_ROAD)) {
-                player->lakitu_props &= ~(LAKITU_LAVA | LAKITU_WATER);
+                player->lakituProps &= ~(LAKITU_LAVA | LAKITU_WATER);
             }
         }
     }
@@ -1848,8 +1848,8 @@ void func_80090970(Player* player, s8 playerId, s8 arg2) {
     clean_effect(player, playerId);
     switch (player->unk_222) {
         case 0:
-            if ((player->lakitu_props & LAKITU_RETRIEVAL) == LAKITU_RETRIEVAL) {
-                if ((player->unk_0C8 < 0x3C) || ((player->lakitu_props & HELD_BY_LAKITU) != HELD_BY_LAKITU)) {
+            if ((player->lakituProps & LAKITU_RETRIEVAL) == LAKITU_RETRIEVAL) {
+                if ((player->unk_0C8 < 0x3C) || ((player->lakituProps & HELD_BY_LAKITU) != HELD_BY_LAKITU)) {
                     player->unk_0C8++;
                     if (player->unk_0C8 >= 0x3C) {
                         player->unk_0C8 = 0x003C;
@@ -1859,16 +1859,16 @@ void func_80090970(Player* player, s8 playerId, s8 arg2) {
                     move_s16_towards(&player->unk_0CC[arg2], 0, 0.2f);
                     if ((D_801652A0[playerId] + 40.0f) <= player->pos[1]) {
                         player->unk_222 = 1;
-                        player->lakitu_props |= LAKITU_FIZZLE;
+                        player->lakituProps |= LAKITU_FIZZLE;
                         player->alpha = 0x00FF;
                     }
                 }
-            } else if ((player->lakitu_props & HELD_BY_LAKITU) == HELD_BY_LAKITU) {
+            } else if ((player->lakituProps & HELD_BY_LAKITU) == HELD_BY_LAKITU) {
                 move_f32_towards(&player->pos[1], player->unk_074 + 100.0f, 0.025f);
                 move_s16_towards(&player->unk_0CC[arg2], 0, 0.2f);
                 if ((player->unk_074 + 40.0f) <= player->pos[1]) {
                     player->unk_222 = 1;
-                    player->lakitu_props |= LAKITU_FIZZLE;
+                    player->lakituProps |= LAKITU_FIZZLE;
                     player->alpha = 0x00FF;
                 }
             }
@@ -1880,13 +1880,13 @@ void func_80090970(Player* player, s8 playerId, s8 arg2) {
             if (((player->type & PLAYER_HUMAN) == PLAYER_HUMAN) && ((player->type & PLAYER_CPU) == 0)) {
                 func_8009E088(playerId, 0xA);
             }
-            if ((player->lakitu_props & LAKITU_RETRIEVAL) == LAKITU_RETRIEVAL) {
+            if ((player->lakituProps & LAKITU_RETRIEVAL) == LAKITU_RETRIEVAL) {
                 move_f32_towards(&player->pos[1], D_801652A0[playerId] + 40.0f, 0.02f);
                 player->alpha -= 8;
                 if (player->alpha < 9) {
                     player->alpha = 0;
                     player->unk_222 = 2;
-                    player->lakitu_props &= ~LAKITU_RETRIEVAL;
+                    player->lakituProps &= ~LAKITU_RETRIEVAL;
                 }
             } else {
                 move_f32_towards(&player->pos[1], player->oldPos[1] + 40.0f, 0.02f);
@@ -1896,7 +1896,7 @@ void func_80090970(Player* player, s8 playerId, s8 arg2) {
                     player->unk_222 = 2;
                 }
             }
-            player->lakitu_props &= ~LAKITU_WATER;
+            player->lakituProps &= ~LAKITU_WATER;
             break;
         case 2:
             func_80090178(player, playerId, sp44, sp38);
@@ -1922,7 +1922,7 @@ void func_80090970(Player* player, s8 playerId, s8 arg2) {
             if (player->alpha >= 0xF0) {
                 player->alpha = 0x00FF;
                 player->unk_222 = 4;
-                player->lakitu_props &= ~LAKITU_FIZZLE;
+                player->lakituProps &= ~LAKITU_FIZZLE;
                 player->unk_0C8 = 0;
             }
             break;
@@ -1940,7 +1940,7 @@ void func_80090970(Player* player, s8 playerId, s8 arg2) {
             move_f32_towards(&player->pos[1], (player->unk_074 + player->boundingBoxSize) - 2.0f, 0.04f);
             player->unk_0C8++;
             if (((player->effects & MIDAIR_EFFECT) != MIDAIR_EFFECT) || (player->effects & ENEMY_BONK_EFFECT)) {
-                player->lakitu_props &= ~LAKITU_LAVA;
+                player->lakituProps &= ~LAKITU_LAVA;
                 if (player->unk_0C8 >= 0x5B) {
                     if (player->type & PLAYER_HUMAN) {
                         func_800C9018(playerId, SOUND_ARG_LOAD(0x01, 0x00, 0xFA, 0x28));
@@ -1948,10 +1948,10 @@ void func_80090970(Player* player, s8 playerId, s8 arg2) {
                     if (gModeSelection == BATTLE) {
                         pop_player_balloon(player, playerId);
                     }
-                    player->lakitu_props &= ~HELD_BY_LAKITU;
+                    player->lakituProps &= ~HELD_BY_LAKITU;
                     player->oobProps &= ~UNDER_FLUID_LEVEL;
-                    if ((player->lakitu_props & FROZEN_EFFECT) != FROZEN_EFFECT) {
-                        player->lakitu_props &= ~LAKITU_SCENE;
+                    if ((player->lakituProps & FROZEN_EFFECT) != FROZEN_EFFECT) {
+                        player->lakituProps &= ~LAKITU_SCENE;
                         if ((player->topSpeed * 0.9) <= player->currentSpeed) {
                             func_8008F104(player, playerId);
                         }
@@ -1988,8 +1988,8 @@ void func_80090970(Player* player, s8 playerId, s8 arg2) {
 
 bool prevent_item_use(Player* player) {
     s32 phi_v0 = 0;
-    if ((((((player->lakitu_props & HELD_BY_LAKITU) == HELD_BY_LAKITU) ||
-           ((player->lakitu_props & LAKITU_SCENE) == LAKITU_SCENE)) ||
+    if ((((((player->lakituProps & HELD_BY_LAKITU) == HELD_BY_LAKITU) ||
+           ((player->lakituProps & LAKITU_SCENE) == LAKITU_SCENE)) ||
           ((player->type & PLAYER_UNKNOWN_0x40) != 0)) ||
          ((player->type & PLAYER_CINEMATIC_MODE) != 0)) ||
         ((player->type & PLAYER_EXISTS) == 0)) {

--- a/src/effects.c
+++ b/src/effects.c
@@ -1346,7 +1346,7 @@ void func_8008F494(Player* player, s8 playerIndex) {
     player->unk_042 = 0;
 
     if (((player->type & PLAYER_HUMAN) != 0) && ((player->type & PLAYER_INVISIBLE_OR_BOMB) == 0) &&
-        ((player->unk_0CA & UNK_0CA_HELD_BY_LAKITU) == 0) && ((player->unk_0DE & 1) == 0) && ((player->unk_0DE & 2) == 0)) {
+        ((player->unk_0CA & UNK_0CA_HELD_BY_LAKITU) == 0) && ((player->unk_0DE & UNK_0DE_UNDER_OOB_OR_FLUID_LEVEL) == 0) && ((player->unk_0DE & UNK_0DE_PASS_OOB_OR_FLUID_LEVEL) == 0)) {
         func_800C90F4(playerIndex, (player->characterId * 0x10) + 0x29008004);
     }
 }
@@ -1814,14 +1814,14 @@ void func_80090868(Player* player) {
         player->unk_222 = 0;
         player->unk_0CA |= UNK_0CA_HELD_BY_LAKITU;
         player->unk_0C8 = 0;
-        if ((player->unk_0DE & 1) == 1) {
+        if ((player->unk_0DE & UNK_0DE_UNDER_OOB_OR_FLUID_LEVEL) == UNK_0DE_UNDER_OOB_OR_FLUID_LEVEL) {
             if ((gCurrentCourseId == COURSE_BOWSER_CASTLE) || (gCurrentCourseId == COURSE_BIG_DONUT)) {
                 player->unk_0CA |= UNK_0CA_LAKITU_LAVA;
             } else {
                 player->unk_0CA |= UNK_0CA_LAKITU_WATER;
             }
             // removing the water effect for Sherbet Land makes sense. Perhaps rainbow road and skyscraper
-            // had lave instead of an abyss initially?
+            // had lava instead of an abyss initially?
             if ((gCurrentCourseId == COURSE_SHERBET_LAND) || (gCurrentCourseId == COURSE_SKYSCRAPER) ||
                 (gCurrentCourseId == COURSE_RAINBOW_ROAD)) {
                 player->unk_0CA &= ~(UNK_0CA_LAKITU_LAVA | UNK_0CA_LAKITU_WATER);
@@ -1948,7 +1948,7 @@ void func_80090970(Player* player, s8 playerId, s8 arg2) {
                         pop_player_balloon(player, playerId);
                     }
                     player->unk_0CA &= ~UNK_0CA_HELD_BY_LAKITU;
-                    player->unk_0DE &= ~0x0004;
+                    player->unk_0DE &= ~UNK_0DE_UNDER_FLUID_LEVEL;
                     if ((player->unk_0CA & UNK_0CA_FROZEN_EFFECT) != UNK_0CA_FROZEN_EFFECT) {
                         player->unk_0CA &= ~UNK_0CA_LAKITU_SCENE;
                         if ((player->topSpeed * 0.9) <= player->currentSpeed) {

--- a/src/effects.c
+++ b/src/effects.c
@@ -1346,7 +1346,7 @@ void func_8008F494(Player* player, s8 playerIndex) {
     player->unk_042 = 0;
 
     if (((player->type & PLAYER_HUMAN) != 0) && ((player->type & PLAYER_INVISIBLE_OR_BOMB) == 0) &&
-        ((player->lakitu_props & HELD_BY_LAKITU) == 0) && ((player->unk_0DE & UNK_0DE_UNDER_OOB_OR_FLUID_LEVEL) == 0) && ((player->unk_0DE & UNK_0DE_PASS_OOB_OR_FLUID_LEVEL) == 0)) {
+        ((player->lakitu_props & HELD_BY_LAKITU) == 0) && ((player->oobProps & UNDER_OOB_OR_FLUID_LEVEL) == 0) && ((player->oobProps & PASS_OOB_OR_FLUID_LEVEL) == 0)) {
         func_800C90F4(playerIndex, (player->characterId * 0x10) + 0x29008004);
     }
 }
@@ -1814,7 +1814,7 @@ void func_80090868(Player* player) {
         player->unk_222 = 0;
         player->lakitu_props |= HELD_BY_LAKITU;
         player->unk_0C8 = 0;
-        if ((player->unk_0DE & UNK_0DE_UNDER_OOB_OR_FLUID_LEVEL) == UNK_0DE_UNDER_OOB_OR_FLUID_LEVEL) {
+        if ((player->oobProps & UNDER_OOB_OR_FLUID_LEVEL) == UNDER_OOB_OR_FLUID_LEVEL) {
             if ((gCurrentCourseId == COURSE_BOWSER_CASTLE) || (gCurrentCourseId == COURSE_BIG_DONUT)) {
                 player->lakitu_props |= LAKITU_LAVA;
             } else {
@@ -1948,7 +1948,7 @@ void func_80090970(Player* player, s8 playerId, s8 arg2) {
                         pop_player_balloon(player, playerId);
                     }
                     player->lakitu_props &= ~HELD_BY_LAKITU;
-                    player->unk_0DE &= ~UNK_0DE_UNDER_FLUID_LEVEL;
+                    player->oobProps &= ~UNDER_FLUID_LEVEL;
                     if ((player->lakitu_props & FROZEN_EFFECT) != FROZEN_EFFECT) {
                         player->lakitu_props &= ~LAKITU_SCENE;
                         if ((player->topSpeed * 0.9) <= player->currentSpeed) {

--- a/src/effects.c
+++ b/src/effects.c
@@ -470,7 +470,7 @@ void func_8008D170(Player* player, s8 playerIndex) {
         var_v1 = 0;
         var_a3 = -var_a3;
         var_f0 *= 0.9;
-        if (((player->effects & BRAKING_EFFECT) == BRAKING_EFFECT) || !(player->unk_044 & 0x20)) {
+        if (((player->effects & BRAKING_EFFECT) == BRAKING_EFFECT) || !(player->unk_044 & UNK_044_PRESS_A)) {
             player->effects |= BANANA_SPINOUT_SAVE_EFFECT;
         }
         if (var_f0 <= 1.3) {
@@ -1468,9 +1468,9 @@ void apply_boo_effect(Player* player, s8 playerIndex) {
 
 void trigger_boo(Player* player, s8 playerIndex) {
     s16 temp_v1;
-
+    // become boo
     if ((player->type & PLAYER_HUMAN) != 0) {
-        player->unk_044 |= 0x200;
+        player->unk_044 |= UNK_044_BECOME_INVISIBLE;
 
         for (temp_v1 = 0; temp_v1 < 10; ++temp_v1) {
             player->particles[temp_v1].IsAlive = 0;
@@ -1551,7 +1551,7 @@ void func_8008FD4C(Player* player, UNUSED s8 arg1) {
     s16 temp_v0;
 
     player->triggers |= LOSE_BATTLE_EFFECT;
-    player->unk_044 |= 0x200;
+    player->unk_044 |= UNK_044_BECOME_INVISIBLE;
 
     for (temp_v0 = 0; temp_v0 < 10; ++temp_v0) {
         player->particles[temp_v0].IsAlive = 0;
@@ -1559,10 +1559,10 @@ void func_8008FD4C(Player* player, UNUSED s8 arg1) {
         player->particles[temp_v0].type = 0;
     }
 }
-
+// become bomb
 void func_8008FDA8(Player* player, UNUSED s8 arg1) {
     s16 temp_v0;
-    player->unk_044 |= 0x200;
+    player->unk_044 |= UNK_044_BECOME_INVISIBLE;
     for (temp_v0 = 0; temp_v0 < 10; ++temp_v0) {
         player->particles[temp_v0].IsAlive = 0;
         player->particles[temp_v0].timer = 0;
@@ -2016,6 +2016,7 @@ bool prevent_item_use(Player* player) {
     }
 }
 
+//UNUSED
 void func_800911B4(Player* player, s8 arg1) {
     s32 temp_v0;
 
@@ -2059,6 +2060,7 @@ void func_800911B4(Player* player, s8 arg1) {
     } while (temp_v0 < 10);
 }
 
+// unused
 void func_80091298(Player* player, s8 arg1) {
     s16 var_v1;
     UNUSED s32 stackPadding1;

--- a/src/effects.c
+++ b/src/effects.c
@@ -313,7 +313,7 @@ void func_8008C8C4(Player* player, s8 playerId) {
         player->currentSpeed = (f32) (player->currentSpeed + 100.0f);
     }
     if ((gModeSelection == VERSUS) && ((player->type & PLAYER_CPU) == PLAYER_CPU) && (!gDemoMode) &&
-        ((player->unk_0CA & UNK_0CA_HELD_BY_LAKITU) == 0) && (gGPCurrentRaceRankByPlayerId[playerId] != 0)) {
+        ((player->lakitu_props & HELD_BY_LAKITU) == 0) && (gGPCurrentRaceRankByPlayerId[playerId] != 0)) {
         player->triggers = (s32) (player->triggers | VERTICAL_TUMBLE_TRIGGER);
     }
 }
@@ -1346,7 +1346,7 @@ void func_8008F494(Player* player, s8 playerIndex) {
     player->unk_042 = 0;
 
     if (((player->type & PLAYER_HUMAN) != 0) && ((player->type & PLAYER_INVISIBLE_OR_BOMB) == 0) &&
-        ((player->unk_0CA & UNK_0CA_HELD_BY_LAKITU) == 0) && ((player->unk_0DE & UNK_0DE_UNDER_OOB_OR_FLUID_LEVEL) == 0) && ((player->unk_0DE & UNK_0DE_PASS_OOB_OR_FLUID_LEVEL) == 0)) {
+        ((player->lakitu_props & HELD_BY_LAKITU) == 0) && ((player->unk_0DE & UNK_0DE_UNDER_OOB_OR_FLUID_LEVEL) == 0) && ((player->unk_0DE & UNK_0DE_PASS_OOB_OR_FLUID_LEVEL) == 0)) {
         func_800C90F4(playerIndex, (player->characterId * 0x10) + 0x29008004);
     }
 }
@@ -1773,7 +1773,7 @@ void func_80090778(Player* player) {
     player->unk_078 = 0;
     player->unk_07C = 0;
     player->unk_0C0 = 0;
-    player->unk_0CA |= UNK_0CA_LAKITU_SCENE;
+    player->lakitu_props |= LAKITU_SCENE;
     player->effects &= ~DRIFTING_EFFECT;
     player->unk_222 = 0;
     player->unk_08C = 0.0f;
@@ -1806,25 +1806,25 @@ void func_80090868(Player* player) {
     player->unk_08C = 0.0f;
     playerIndex = get_player_index_for_player(player);
 
-    if ((player->unk_0CA & UNK_0CA_HELD_BY_LAKITU) != UNK_0CA_HELD_BY_LAKITU) {
+    if ((player->lakitu_props & HELD_BY_LAKITU) != HELD_BY_LAKITU) {
         player->unk_D98 = 1;
         player->unk_D9C = 0.0f;
         player->unk_DA0 = 0.5f;
         course_update_path_point(player, playerIndex);
         player->unk_222 = 0;
-        player->unk_0CA |= UNK_0CA_HELD_BY_LAKITU;
+        player->lakitu_props |= HELD_BY_LAKITU;
         player->unk_0C8 = 0;
         if ((player->unk_0DE & UNK_0DE_UNDER_OOB_OR_FLUID_LEVEL) == UNK_0DE_UNDER_OOB_OR_FLUID_LEVEL) {
             if ((gCurrentCourseId == COURSE_BOWSER_CASTLE) || (gCurrentCourseId == COURSE_BIG_DONUT)) {
-                player->unk_0CA |= UNK_0CA_LAKITU_LAVA;
+                player->lakitu_props |= LAKITU_LAVA;
             } else {
-                player->unk_0CA |= UNK_0CA_LAKITU_WATER;
+                player->lakitu_props |= LAKITU_WATER;
             }
             // removing the water effect for Sherbet Land makes sense. Perhaps rainbow road and skyscraper
             // had lava instead of an abyss initially?
             if ((gCurrentCourseId == COURSE_SHERBET_LAND) || (gCurrentCourseId == COURSE_SKYSCRAPER) ||
                 (gCurrentCourseId == COURSE_RAINBOW_ROAD)) {
-                player->unk_0CA &= ~(UNK_0CA_LAKITU_LAVA | UNK_0CA_LAKITU_WATER);
+                player->lakitu_props &= ~(LAKITU_LAVA | LAKITU_WATER);
             }
         }
     }
@@ -1847,8 +1847,8 @@ void func_80090970(Player* player, s8 playerId, s8 arg2) {
     clean_effect(player, playerId);
     switch (player->unk_222) {
         case 0:
-            if ((player->unk_0CA & UNK_0CA_LAKITU_RETRIEVAL) == UNK_0CA_LAKITU_RETRIEVAL) {
-                if ((player->unk_0C8 < 0x3C) || ((player->unk_0CA & UNK_0CA_HELD_BY_LAKITU) != UNK_0CA_HELD_BY_LAKITU)) {
+            if ((player->lakitu_props & LAKITU_RETRIEVAL) == LAKITU_RETRIEVAL) {
+                if ((player->unk_0C8 < 0x3C) || ((player->lakitu_props & HELD_BY_LAKITU) != HELD_BY_LAKITU)) {
                     player->unk_0C8++;
                     if (player->unk_0C8 >= 0x3C) {
                         player->unk_0C8 = 0x003C;
@@ -1858,16 +1858,16 @@ void func_80090970(Player* player, s8 playerId, s8 arg2) {
                     move_s16_towards(&player->unk_0CC[arg2], 0, 0.2f);
                     if ((D_801652A0[playerId] + 40.0f) <= player->pos[1]) {
                         player->unk_222 = 1;
-                        player->unk_0CA |= UNK_0CA_LAKITU_FIZZLE;
+                        player->lakitu_props |= LAKITU_FIZZLE;
                         player->alpha = 0x00FF;
                     }
                 }
-            } else if ((player->unk_0CA & UNK_0CA_HELD_BY_LAKITU) == UNK_0CA_HELD_BY_LAKITU) {
+            } else if ((player->lakitu_props & HELD_BY_LAKITU) == HELD_BY_LAKITU) {
                 move_f32_towards(&player->pos[1], player->unk_074 + 100.0f, 0.025f);
                 move_s16_towards(&player->unk_0CC[arg2], 0, 0.2f);
                 if ((player->unk_074 + 40.0f) <= player->pos[1]) {
                     player->unk_222 = 1;
-                    player->unk_0CA |= UNK_0CA_LAKITU_FIZZLE;
+                    player->lakitu_props |= LAKITU_FIZZLE;
                     player->alpha = 0x00FF;
                 }
             }
@@ -1879,13 +1879,13 @@ void func_80090970(Player* player, s8 playerId, s8 arg2) {
             if (((player->type & PLAYER_HUMAN) == PLAYER_HUMAN) && ((player->type & PLAYER_CPU) == 0)) {
                 func_8009E088(playerId, 0xA);
             }
-            if ((player->unk_0CA & UNK_0CA_LAKITU_RETRIEVAL) == UNK_0CA_LAKITU_RETRIEVAL) {
+            if ((player->lakitu_props & LAKITU_RETRIEVAL) == LAKITU_RETRIEVAL) {
                 move_f32_towards(&player->pos[1], D_801652A0[playerId] + 40.0f, 0.02f);
                 player->alpha -= 8;
                 if (player->alpha < 9) {
                     player->alpha = 0;
                     player->unk_222 = 2;
-                    player->unk_0CA &= ~UNK_0CA_LAKITU_RETRIEVAL;
+                    player->lakitu_props &= ~LAKITU_RETRIEVAL;
                 }
             } else {
                 move_f32_towards(&player->pos[1], player->oldPos[1] + 40.0f, 0.02f);
@@ -1895,7 +1895,7 @@ void func_80090970(Player* player, s8 playerId, s8 arg2) {
                     player->unk_222 = 2;
                 }
             }
-            player->unk_0CA &= ~UNK_0CA_LAKITU_WATER;
+            player->lakitu_props &= ~LAKITU_WATER;
             break;
         case 2:
             func_80090178(player, playerId, sp44, sp38);
@@ -1921,7 +1921,7 @@ void func_80090970(Player* player, s8 playerId, s8 arg2) {
             if (player->alpha >= 0xF0) {
                 player->alpha = 0x00FF;
                 player->unk_222 = 4;
-                player->unk_0CA &= ~UNK_0CA_LAKITU_FIZZLE;
+                player->lakitu_props &= ~LAKITU_FIZZLE;
                 player->unk_0C8 = 0;
             }
             break;
@@ -1939,7 +1939,7 @@ void func_80090970(Player* player, s8 playerId, s8 arg2) {
             move_f32_towards(&player->pos[1], (player->unk_074 + player->boundingBoxSize) - 2.0f, 0.04f);
             player->unk_0C8++;
             if (((player->effects & MIDAIR_EFFECT) != MIDAIR_EFFECT) || (player->effects & ENEMY_BONK_EFFECT)) {
-                player->unk_0CA &= ~UNK_0CA_LAKITU_LAVA;
+                player->lakitu_props &= ~LAKITU_LAVA;
                 if (player->unk_0C8 >= 0x5B) {
                     if (player->type & PLAYER_HUMAN) {
                         func_800C9018(playerId, SOUND_ARG_LOAD(0x01, 0x00, 0xFA, 0x28));
@@ -1947,10 +1947,10 @@ void func_80090970(Player* player, s8 playerId, s8 arg2) {
                     if (gModeSelection == BATTLE) {
                         pop_player_balloon(player, playerId);
                     }
-                    player->unk_0CA &= ~UNK_0CA_HELD_BY_LAKITU;
+                    player->lakitu_props &= ~HELD_BY_LAKITU;
                     player->unk_0DE &= ~UNK_0DE_UNDER_FLUID_LEVEL;
-                    if ((player->unk_0CA & UNK_0CA_FROZEN_EFFECT) != UNK_0CA_FROZEN_EFFECT) {
-                        player->unk_0CA &= ~UNK_0CA_LAKITU_SCENE;
+                    if ((player->lakitu_props & FROZEN_EFFECT) != FROZEN_EFFECT) {
+                        player->lakitu_props &= ~LAKITU_SCENE;
                         if ((player->topSpeed * 0.9) <= player->currentSpeed) {
                             func_8008F104(player, playerId);
                         }
@@ -1987,7 +1987,7 @@ void func_80090970(Player* player, s8 playerId, s8 arg2) {
 
 bool prevent_item_use(Player* player) {
     s32 phi_v0 = 0;
-    if ((((((player->unk_0CA & UNK_0CA_HELD_BY_LAKITU) == UNK_0CA_HELD_BY_LAKITU) || ((player->unk_0CA & UNK_0CA_LAKITU_SCENE) == UNK_0CA_LAKITU_SCENE)) ||
+    if ((((((player->lakitu_props & HELD_BY_LAKITU) == HELD_BY_LAKITU) || ((player->lakitu_props & LAKITU_SCENE) == LAKITU_SCENE)) ||
           ((player->type & PLAYER_UNKNOWN_0x40) != 0)) ||
          ((player->type & PLAYER_CINEMATIC_MODE) != 0)) ||
         ((player->type & PLAYER_EXISTS) == 0)) {

--- a/src/effects.c
+++ b/src/effects.c
@@ -157,7 +157,7 @@ void clean_effect(Player* player, s8 playerIndex) {
     if ((player->effects & BANANA_NEAR_SPINOUT_EFFECT) == BANANA_NEAR_SPINOUT_EFFECT) {
         func_8008D0E4(player, playerIndex);
     }
-    if ((player->unk_044 & 0x4000) != 0) {
+    if ((player->unk_044 & UNK_044_DRIVING_SPINOUT) != 0) {
         func_8008D3B0(player, playerIndex);
     }
     if ((player->effects & MUSHROOM_EFFECT) == MUSHROOM_EFFECT) {
@@ -190,7 +190,7 @@ void clean_effect(Player* player, s8 playerIndex) {
     if ((player->effects & UNKNOWN_EFFECT_0x10000000) == UNKNOWN_EFFECT_0x10000000) {
         func_8008FEDC(player, playerIndex);
     }
-    player->unk_044 = (s16) (player->unk_044 & 0xFFFE);
+    player->unk_044 = (s16) (player->unk_044 & ~UNK_044_BACK_UP);
     player->effects = (s32) (player->effects & ~AB_SPIN_EFFECT);
 }
 
@@ -452,7 +452,7 @@ void func_8008D0FC(Player* player, s8 playerIndex) {
     player->unk_0B8 = 2.0f;
     player->unk_0AC = 1;
     player->effects &= ~DRIFTING_EFFECT;
-    player->unk_044 |= 0x4000;
+    player->unk_044 |= UNK_044_DRIVING_SPINOUT;
 }
 
 void func_8008D170(Player* player, s8 playerIndex) {
@@ -474,7 +474,7 @@ void func_8008D170(Player* player, s8 playerIndex) {
             player->effects |= BANANA_SPINOUT_SAVE_EFFECT;
         }
         if (var_f0 <= 1.3) {
-            player->unk_044 &= ~0x4000;
+            player->unk_044 &= ~UNK_044_DRIVING_SPINOUT;
             if ((player->effects & BANANA_SPINOUT_SAVE_EFFECT) != BANANA_SPINOUT_SAVE_EFFECT) {
                 func_8008C73C(player, playerIndex);
                 var_v1 = 0;
@@ -501,12 +501,12 @@ void func_8008D170(Player* player, s8 playerIndex) {
     player->unk_0AC = var_a3;
     if (player->effects & MIDAIR_EFFECT) {
         func_8008C73C(player, playerIndex);
-        player->unk_044 &= ~0x4000;
+        player->unk_044 &= ~UNK_044_DRIVING_SPINOUT;
     }
 }
 
 void func_8008D3B0(Player* player, UNUSED s8 playerIndex) {
-    player->unk_044 &= 0xBFFF;
+    player->unk_044 &= ~UNK_044_DRIVING_SPINOUT;
 }
 
 void trigger_shroom(Player* player, s8 playerIndex) {
@@ -1167,7 +1167,7 @@ void trigger_asphalt_ramp_boost(Player* player, s8 playerId) {
         func_800C90F4(playerId, (player->characterId * 0x10) + 0x29008001);
         func_800C9060(playerId, 0x1900A40B);
     }
-    player->unk_044 &= ~0x1;
+    player->unk_044 &= ~UNK_044_BACK_UP;
     player->effects &= ~AB_SPIN_EFFECT;
 }
 
@@ -1215,7 +1215,7 @@ void trigger_wood_ramp_boost(Player* player, s8 playerId) {
         func_800C9060(playerId, 0x1900A40B);
     }
 
-    player->unk_044 &= ~0x1;
+    player->unk_044 &= ~UNK_044_BACK_UP;
     player->effects &= ~AB_SPIN_EFFECT;
 }
 
@@ -1263,7 +1263,7 @@ void func_8008F1B8(Player* player, s8 arg1) {
 
     player->unk_08C = (player->unk_210 * 0.05);
     if (player->unk_0B2 < 0) {
-        if ((player->unk_044 & 0x80) == 0x80) {
+        if ((player->unk_044 & UNK_044_EARLY_SPINOUT_LEFT) == UNK_044_EARLY_SPINOUT_LEFT) {
             player->rotation[1] += 182;
             D_8018D920[arg1] += 182;
 
@@ -1292,8 +1292,8 @@ void func_8008F1B8(Player* player, s8 arg1) {
             if (temp < 71) {
                 --player->unk_0B2;
             }
-            player->unk_044 |= 0x80;
-            player->unk_044 &= ~0x40;
+            player->unk_044 |= UNK_044_EARLY_SPINOUT_LEFT;
+            player->unk_044 &= ~UNK_044_EARLY_SPINOUT_RIGHT;
             return;
         }
         player->rotation[1] += 364;
@@ -1302,8 +1302,8 @@ void func_8008F1B8(Player* player, s8 arg1) {
         if (temp >= 110) {
             --player->unk_0B2;
         }
-        player->unk_044 |= 0x40;
-        player->unk_044 &= ~0x80;
+        player->unk_044 |= UNK_044_EARLY_SPINOUT_RIGHT;
+        player->unk_044 &= ~UNK_044_EARLY_SPINOUT_LEFT;
     }
 }
 
@@ -1333,7 +1333,7 @@ void func_8008F494(Player* player, s8 playerIndex) {
          ((player->effects & EXPLOSION_CRASH_EFFECT)) || ((player->effects & HIT_BY_STAR_EFFECT)) ||
          ((player->effects & HIT_BY_GREEN_SHELL_EFFECT) != 0)) &&
         (gModeSelection == BATTLE)) {
-        player->unk_044 |= 0x8000;
+        player->unk_044 |= UNK_044_UNKNOWN_BATTLE_VAR;
     }
 
     clean_effect(player, playerIndex);
@@ -1353,9 +1353,9 @@ void func_8008F494(Player* player, s8 playerIndex) {
 
 void func_8008F5A4(Player* player, s8 playerIndex) {
 
-    if ((player->unk_044 & 0x8000) != 0) {
+    if ((player->unk_044 & UNK_044_UNKNOWN_BATTLE_VAR) != 0) {
         pop_player_balloon(player, playerIndex);
-        player->unk_044 &= ~0x8000;
+        player->unk_044 &= ~UNK_044_UNKNOWN_BATTLE_VAR;
     }
 
     player->unk_206 = 0;
@@ -2021,9 +2021,9 @@ void func_800911B4(Player* player, s8 arg1) {
     s32 temp_v0;
 
     player->unk_0AE = player->rotation[1];
-    player->unk_044 |= 0x1800;
-    player->unk_044 &= ~0x0400;
-    player->unk_044 |= 0x2000;
+    player->unk_044 |= (UNK_044_UNUSED_0x1000 | UNK_044_UNUSED_0x800);
+    player->unk_044 &= ~UNK_044_UNUSED_0x400;
+    player->unk_044 |= UNK_044_UNUSED_0x2000;
     player->kartHopJerk = 0.002f;
     player->kartHopAcceleration = 0.0f;
     player->kartHopVelocity = 2.6f;
@@ -2066,7 +2066,7 @@ void func_80091298(Player* player, s8 arg1) {
     UNUSED s32 stackPadding1;
     Vec3f spC = { 27.167f, 25.167f, 23.167f };
 
-    player->unk_044 |= 0x2000;
+    player->unk_044 |= UNK_044_UNUSED_0x2000;
     if (player->unk_0B2 == 0) {
         var_v1 = 0;
     } else {
@@ -2088,7 +2088,7 @@ void func_80091298(Player* player, s8 arg1) {
                 player->unk_07C = 0;
                 player->unk_0C0 = 0;
                 player->unk_DB4.unkC = 3.0f;
-                player->unk_044 &= ~0x800;
+                player->unk_044 &= ~UNK_044_UNUSED_0x800;
                 player->kartGravity = gKartGravityTable[player->characterId];
                 player->unk_0D4[0] = 0;
                 player->type |= PLAYER_START_SEQUENCE;
@@ -2104,8 +2104,8 @@ void func_80091298(Player* player, s8 arg1) {
 }
 
 void func_80091440(s8 arg0) {
-    if ((gPlayers[arg0].unk_044 & 0x800) == 0) {
-        gPlayers[arg0].unk_044 |= 0x2400;
+    if ((gPlayers[arg0].unk_044 & UNK_044_UNUSED_0x800) == 0) {
+        gPlayers[arg0].unk_044 |= (UNK_044_UNUSED_0x2000 | UNK_044_UNUSED_0x400);
         gPlayers[arg0].type &= ~0x2000;
     }
 }

--- a/src/effects.c
+++ b/src/effects.c
@@ -137,7 +137,7 @@ void func_8008C310(Player* player) {
     // The << 9 is a hacky way to check for VERTICAL_TUMBLE_TRIGGER
     if ((player->triggers & HIGH_TUMBLE_TRIGGER) || (player->triggers & LOW_TUMBLE_TRIGGER) || ((player->triggers << 9) < 0) ||
         (player->triggers & HIT_BY_STAR_TRIGGER)) {
-        player->unk_0B6 = ((u16) player->unk_0B6 | UNK_0B6_EXPLOSION);
+        player->kart_graphics = ((u16) player->kart_graphics | EXPLOSION);
     }
 }
 
@@ -269,7 +269,7 @@ void func_8008C73C(Player* player, s8 playerIndex) {
             player->effects |= BANANA_SPINOUT_EFFECT;
         }
 
-        player->unk_0B6 |= UNK_0B6_WHIRRR;
+        player->kart_graphics |= WHIRRR;
         // clang-format off
         player->unk_0C0 = 0; player->unk_07C = 0; player->unk_078 = 0; player->unk_0AE = player->rotation[1]; player->unk_0B2 = 2;
         // clang-format on
@@ -414,7 +414,7 @@ void func_8008CEB0(Player* player, s8 playerIndex) {
                 func_8008C73C(player, playerIndex);
                 var_v1 = 0;
             } else {
-                player->unk_0B6 |= UNK_0B6_WHISTLE;
+                player->kart_graphics |= WHISTLE;
                 player->effects &= ~BANANA_SPINOUT_SAVE_EFFECT;
                 if ((player->type & PLAYER_HUMAN) == PLAYER_HUMAN) {
                     func_800C90F4(playerIndex, (player->characterId * 0x10) + 0x29008008);
@@ -479,7 +479,7 @@ void func_8008D170(Player* player, s8 playerIndex) {
                 func_8008C73C(player, playerIndex);
                 var_v1 = 0;
             } else {
-                player->unk_0B6 |= UNK_0B6_WHISTLE;
+                player->kart_graphics |= WHISTLE;
                 player->effects &= ~BANANA_SPINOUT_SAVE_EFFECT;
                 if ((player->type & PLAYER_HUMAN) == PLAYER_HUMAN) {
                     func_800C90F4(playerIndex, (player->characterId * 0x10) + 0x29008008);
@@ -1031,7 +1031,7 @@ void trigger_vertical_tumble(Player* player, s8 playerIndex) {
     }
 
     player->triggers &= ~(VERTICAL_TUMBLE_TRIGGER | HIT_PADDLE_BOAT_TRIGGER);
-    player->unk_0B6 |= UNK_0B6_CRASH;
+    player->kart_graphics |= CRASH;
     gTimerBoostTripleACombo[playerIndex] = 0;
     gIsPlayerTripleAButtonCombo[playerIndex] = false;
     gCountASwitch[playerIndex] = 0;
@@ -1131,7 +1131,7 @@ void trigger_high_tumble(Player* player, s8 playerIndex) {
     }
 
     player->effects |= HIT_BY_STAR_EFFECT;
-    player->unk_0B6 |= UNK_0B6_CRASH;
+    player->kart_graphics |= CRASH;
     player->triggers &= ~(HIT_BY_STAR_TRIGGER | HIGH_TUMBLE_TRIGGER);
 
     gTimerBoostTripleACombo[playerIndex] = 0;

--- a/src/effects.c
+++ b/src/effects.c
@@ -135,8 +135,8 @@ UNUSED void func_unnamed33(void) {
 
 void func_8008C310(Player* player) {
     // The << 9 is a hacky way to check for VERTICAL_TUMBLE_TRIGGER
-    if ((player->triggers & HIGH_TUMBLE_TRIGGER) || (player->triggers & LOW_TUMBLE_TRIGGER) || ((player->triggers << 9) < 0) ||
-        (player->triggers & HIT_BY_STAR_TRIGGER)) {
+    if ((player->triggers & HIGH_TUMBLE_TRIGGER) || (player->triggers & LOW_TUMBLE_TRIGGER) ||
+        ((player->triggers << 9) < 0) || (player->triggers & HIT_BY_STAR_TRIGGER)) {
         player->kart_graphics = ((u16) player->kart_graphics | EXPLOSION);
     }
 }
@@ -1346,7 +1346,8 @@ void func_8008F494(Player* player, s8 playerIndex) {
     player->unk_042 = 0;
 
     if (((player->type & PLAYER_HUMAN) != 0) && ((player->type & PLAYER_INVISIBLE_OR_BOMB) == 0) &&
-        ((player->lakitu_props & HELD_BY_LAKITU) == 0) && ((player->oobProps & UNDER_OOB_OR_FLUID_LEVEL) == 0) && ((player->oobProps & PASS_OOB_OR_FLUID_LEVEL) == 0)) {
+        ((player->lakitu_props & HELD_BY_LAKITU) == 0) && ((player->oobProps & UNDER_OOB_OR_FLUID_LEVEL) == 0) &&
+        ((player->oobProps & PASS_OOB_OR_FLUID_LEVEL) == 0)) {
         func_800C90F4(playerIndex, (player->characterId * 0x10) + 0x29008004);
     }
 }
@@ -1987,7 +1988,8 @@ void func_80090970(Player* player, s8 playerId, s8 arg2) {
 
 bool prevent_item_use(Player* player) {
     s32 phi_v0 = 0;
-    if ((((((player->lakitu_props & HELD_BY_LAKITU) == HELD_BY_LAKITU) || ((player->lakitu_props & LAKITU_SCENE) == LAKITU_SCENE)) ||
+    if ((((((player->lakitu_props & HELD_BY_LAKITU) == HELD_BY_LAKITU) ||
+           ((player->lakitu_props & LAKITU_SCENE) == LAKITU_SCENE)) ||
           ((player->type & PLAYER_UNKNOWN_0x40) != 0)) ||
          ((player->type & PLAYER_CINEMATIC_MODE) != 0)) ||
         ((player->type & PLAYER_EXISTS) == 0)) {

--- a/src/effects.c
+++ b/src/effects.c
@@ -137,7 +137,7 @@ void func_8008C310(Player* player) {
     // The << 9 is a hacky way to check for VERTICAL_TUMBLE_TRIGGER
     if ((player->triggers & HIGH_TUMBLE_TRIGGER) || (player->triggers & LOW_TUMBLE_TRIGGER) || ((player->triggers << 9) < 0) ||
         (player->triggers & HIT_BY_STAR_TRIGGER)) {
-        player->unk_0B6 = ((u16) player->unk_0B6 | 0x1000);
+        player->unk_0B6 = ((u16) player->unk_0B6 | UNK_0B6_EXPLOSION);
     }
 }
 
@@ -269,7 +269,7 @@ void func_8008C73C(Player* player, s8 playerIndex) {
             player->effects |= BANANA_SPINOUT_EFFECT;
         }
 
-        player->unk_0B6 |= 0x80;
+        player->unk_0B6 |= UNK_0B6_WHIRRR;
         // clang-format off
         player->unk_0C0 = 0; player->unk_07C = 0; player->unk_078 = 0; player->unk_0AE = player->rotation[1]; player->unk_0B2 = 2;
         // clang-format on
@@ -414,7 +414,7 @@ void func_8008CEB0(Player* player, s8 playerIndex) {
                 func_8008C73C(player, playerIndex);
                 var_v1 = 0;
             } else {
-                player->unk_0B6 |= 0x20;
+                player->unk_0B6 |= UNK_0B6_WHISTLE;
                 player->effects &= ~BANANA_SPINOUT_SAVE_EFFECT;
                 if ((player->type & PLAYER_HUMAN) == PLAYER_HUMAN) {
                     func_800C90F4(playerIndex, (player->characterId * 0x10) + 0x29008008);
@@ -479,7 +479,7 @@ void func_8008D170(Player* player, s8 playerIndex) {
                 func_8008C73C(player, playerIndex);
                 var_v1 = 0;
             } else {
-                player->unk_0B6 |= 0x20;
+                player->unk_0B6 |= UNK_0B6_WHISTLE;
                 player->effects &= ~BANANA_SPINOUT_SAVE_EFFECT;
                 if ((player->type & PLAYER_HUMAN) == PLAYER_HUMAN) {
                     func_800C90F4(playerIndex, (player->characterId * 0x10) + 0x29008008);
@@ -1031,7 +1031,7 @@ void trigger_vertical_tumble(Player* player, s8 playerIndex) {
     }
 
     player->triggers &= ~(VERTICAL_TUMBLE_TRIGGER | HIT_PADDLE_BOAT_TRIGGER);
-    player->unk_0B6 |= 0x40;
+    player->unk_0B6 |= UNK_0B6_CRASH;
     gTimerBoostTripleACombo[playerIndex] = 0;
     gIsPlayerTripleAButtonCombo[playerIndex] = false;
     gCountASwitch[playerIndex] = 0;
@@ -1131,7 +1131,7 @@ void trigger_high_tumble(Player* player, s8 playerIndex) {
     }
 
     player->effects |= HIT_BY_STAR_EFFECT;
-    player->unk_0B6 |= 0x40;
+    player->unk_0B6 |= UNK_0B6_CRASH;
     player->triggers &= ~(HIT_BY_STAR_TRIGGER | HIGH_TUMBLE_TRIGGER);
 
     gTimerBoostTripleACombo[playerIndex] = 0;

--- a/src/effects.c
+++ b/src/effects.c
@@ -157,7 +157,7 @@ void clean_effect(Player* player, s8 playerIndex) {
     if ((player->effects & BANANA_NEAR_SPINOUT_EFFECT) == BANANA_NEAR_SPINOUT_EFFECT) {
         func_8008D0E4(player, playerIndex);
     }
-    if ((player->unk_044 & UNK_044_DRIVING_SPINOUT) != 0) {
+    if ((player->kartProps & DRIVING_SPINOUT) != 0) {
         func_8008D3B0(player, playerIndex);
     }
     if ((player->effects & MUSHROOM_EFFECT) == MUSHROOM_EFFECT) {
@@ -190,7 +190,7 @@ void clean_effect(Player* player, s8 playerIndex) {
     if ((player->effects & UNKNOWN_EFFECT_0x10000000) == UNKNOWN_EFFECT_0x10000000) {
         func_8008FEDC(player, playerIndex);
     }
-    player->unk_044 = (s16) (player->unk_044 & ~UNK_044_BACK_UP);
+    player->kartProps = (s16) (player->kartProps & ~BACK_UP);
     player->effects = (s32) (player->effects & ~AB_SPIN_EFFECT);
 }
 
@@ -452,7 +452,7 @@ void func_8008D0FC(Player* player, s8 playerIndex) {
     player->unk_0B8 = 2.0f;
     player->unk_0AC = 1;
     player->effects &= ~DRIFTING_EFFECT;
-    player->unk_044 |= UNK_044_DRIVING_SPINOUT;
+    player->kartProps |= DRIVING_SPINOUT;
 }
 
 void func_8008D170(Player* player, s8 playerIndex) {
@@ -470,11 +470,11 @@ void func_8008D170(Player* player, s8 playerIndex) {
         var_v1 = 0;
         var_a3 = -var_a3;
         var_f0 *= 0.9;
-        if (((player->effects & BRAKING_EFFECT) == BRAKING_EFFECT) || !(player->unk_044 & UNK_044_PRESS_A)) {
+        if (((player->effects & BRAKING_EFFECT) == BRAKING_EFFECT) || !(player->kartProps & PRESS_A)) {
             player->effects |= BANANA_SPINOUT_SAVE_EFFECT;
         }
         if (var_f0 <= 1.3) {
-            player->unk_044 &= ~UNK_044_DRIVING_SPINOUT;
+            player->kartProps &= ~DRIVING_SPINOUT;
             if ((player->effects & BANANA_SPINOUT_SAVE_EFFECT) != BANANA_SPINOUT_SAVE_EFFECT) {
                 func_8008C73C(player, playerIndex);
                 var_v1 = 0;
@@ -501,12 +501,12 @@ void func_8008D170(Player* player, s8 playerIndex) {
     player->unk_0AC = var_a3;
     if (player->effects & MIDAIR_EFFECT) {
         func_8008C73C(player, playerIndex);
-        player->unk_044 &= ~UNK_044_DRIVING_SPINOUT;
+        player->kartProps &= ~DRIVING_SPINOUT;
     }
 }
 
 void func_8008D3B0(Player* player, UNUSED s8 playerIndex) {
-    player->unk_044 &= ~UNK_044_DRIVING_SPINOUT;
+    player->kartProps &= ~DRIVING_SPINOUT;
 }
 
 void trigger_shroom(Player* player, s8 playerIndex) {
@@ -1167,7 +1167,7 @@ void trigger_asphalt_ramp_boost(Player* player, s8 playerId) {
         func_800C90F4(playerId, (player->characterId * 0x10) + 0x29008001);
         func_800C9060(playerId, 0x1900A40B);
     }
-    player->unk_044 &= ~UNK_044_BACK_UP;
+    player->kartProps &= ~BACK_UP;
     player->effects &= ~AB_SPIN_EFFECT;
 }
 
@@ -1215,7 +1215,7 @@ void trigger_wood_ramp_boost(Player* player, s8 playerId) {
         func_800C9060(playerId, 0x1900A40B);
     }
 
-    player->unk_044 &= ~UNK_044_BACK_UP;
+    player->kartProps &= ~BACK_UP;
     player->effects &= ~AB_SPIN_EFFECT;
 }
 
@@ -1263,7 +1263,7 @@ void func_8008F1B8(Player* player, s8 arg1) {
 
     player->unk_08C = (player->unk_210 * 0.05);
     if (player->unk_0B2 < 0) {
-        if ((player->unk_044 & UNK_044_EARLY_SPINOUT_LEFT) == UNK_044_EARLY_SPINOUT_LEFT) {
+        if ((player->kartProps & EARLY_SPINOUT_LEFT) == EARLY_SPINOUT_LEFT) {
             player->rotation[1] += 182;
             D_8018D920[arg1] += 182;
 
@@ -1292,8 +1292,8 @@ void func_8008F1B8(Player* player, s8 arg1) {
             if (temp < 71) {
                 --player->unk_0B2;
             }
-            player->unk_044 |= UNK_044_EARLY_SPINOUT_LEFT;
-            player->unk_044 &= ~UNK_044_EARLY_SPINOUT_RIGHT;
+            player->kartProps |= EARLY_SPINOUT_LEFT;
+            player->kartProps &= ~EARLY_SPINOUT_RIGHT;
             return;
         }
         player->rotation[1] += 364;
@@ -1302,8 +1302,8 @@ void func_8008F1B8(Player* player, s8 arg1) {
         if (temp >= 110) {
             --player->unk_0B2;
         }
-        player->unk_044 |= UNK_044_EARLY_SPINOUT_RIGHT;
-        player->unk_044 &= ~UNK_044_EARLY_SPINOUT_LEFT;
+        player->kartProps |= EARLY_SPINOUT_RIGHT;
+        player->kartProps &= ~EARLY_SPINOUT_LEFT;
     }
 }
 
@@ -1333,7 +1333,7 @@ void func_8008F494(Player* player, s8 playerIndex) {
          ((player->effects & EXPLOSION_CRASH_EFFECT)) || ((player->effects & HIT_BY_STAR_EFFECT)) ||
          ((player->effects & HIT_BY_GREEN_SHELL_EFFECT) != 0)) &&
         (gModeSelection == BATTLE)) {
-        player->unk_044 |= UNK_044_UNKNOWN_BATTLE_VAR;
+        player->kartProps |= UNKNOWN_BATTLE_VAR;
     }
 
     clean_effect(player, playerIndex);
@@ -1353,9 +1353,9 @@ void func_8008F494(Player* player, s8 playerIndex) {
 
 void func_8008F5A4(Player* player, s8 playerIndex) {
 
-    if ((player->unk_044 & UNK_044_UNKNOWN_BATTLE_VAR) != 0) {
+    if ((player->kartProps & UNKNOWN_BATTLE_VAR) != 0) {
         pop_player_balloon(player, playerIndex);
-        player->unk_044 &= ~UNK_044_UNKNOWN_BATTLE_VAR;
+        player->kartProps &= ~UNKNOWN_BATTLE_VAR;
     }
 
     player->unk_206 = 0;
@@ -1470,7 +1470,7 @@ void trigger_boo(Player* player, s8 playerIndex) {
     s16 temp_v1;
     // become boo
     if ((player->type & PLAYER_HUMAN) != 0) {
-        player->unk_044 |= UNK_044_BECOME_INVISIBLE;
+        player->kartProps |= BECOME_INVISIBLE;
 
         for (temp_v1 = 0; temp_v1 < 10; ++temp_v1) {
             player->particles[temp_v1].IsAlive = 0;
@@ -1551,7 +1551,7 @@ void func_8008FD4C(Player* player, UNUSED s8 arg1) {
     s16 temp_v0;
 
     player->triggers |= LOSE_BATTLE_EFFECT;
-    player->unk_044 |= UNK_044_BECOME_INVISIBLE;
+    player->kartProps |= BECOME_INVISIBLE;
 
     for (temp_v0 = 0; temp_v0 < 10; ++temp_v0) {
         player->particles[temp_v0].IsAlive = 0;
@@ -1562,7 +1562,7 @@ void func_8008FD4C(Player* player, UNUSED s8 arg1) {
 // become bomb
 void func_8008FDA8(Player* player, UNUSED s8 arg1) {
     s16 temp_v0;
-    player->unk_044 |= UNK_044_BECOME_INVISIBLE;
+    player->kartProps |= BECOME_INVISIBLE;
     for (temp_v0 = 0; temp_v0 < 10; ++temp_v0) {
         player->particles[temp_v0].IsAlive = 0;
         player->particles[temp_v0].timer = 0;
@@ -2022,9 +2022,9 @@ void func_800911B4(Player* player, s8 arg1) {
     s32 temp_v0;
 
     player->unk_0AE = player->rotation[1];
-    player->unk_044 |= (UNK_044_UNUSED_0x1000 | UNK_044_UNUSED_0x800);
-    player->unk_044 &= ~UNK_044_UNUSED_0x400;
-    player->unk_044 |= UNK_044_UNUSED_0x2000;
+    player->kartProps |= (UNUSED_0x1000 | UNUSED_0x800);
+    player->kartProps &= ~UNUSED_0x400;
+    player->kartProps |= UNUSED_0x2000;
     player->kartHopJerk = 0.002f;
     player->kartHopAcceleration = 0.0f;
     player->kartHopVelocity = 2.6f;
@@ -2067,7 +2067,7 @@ void func_80091298(Player* player, s8 arg1) {
     UNUSED s32 stackPadding1;
     Vec3f spC = { 27.167f, 25.167f, 23.167f };
 
-    player->unk_044 |= UNK_044_UNUSED_0x2000;
+    player->kartProps |= UNUSED_0x2000;
     if (player->unk_0B2 == 0) {
         var_v1 = 0;
     } else {
@@ -2089,7 +2089,7 @@ void func_80091298(Player* player, s8 arg1) {
                 player->unk_07C = 0;
                 player->unk_0C0 = 0;
                 player->unk_DB4.unkC = 3.0f;
-                player->unk_044 &= ~UNK_044_UNUSED_0x800;
+                player->kartProps &= ~UNUSED_0x800;
                 player->kartGravity = gKartGravityTable[player->characterId];
                 player->unk_0D4[0] = 0;
                 player->type |= PLAYER_START_SEQUENCE;
@@ -2105,8 +2105,8 @@ void func_80091298(Player* player, s8 arg1) {
 }
 
 void func_80091440(s8 arg0) {
-    if ((gPlayers[arg0].unk_044 & UNK_044_UNUSED_0x800) == 0) {
-        gPlayers[arg0].unk_044 |= (UNK_044_UNUSED_0x2000 | UNK_044_UNUSED_0x400);
+    if ((gPlayers[arg0].kartProps & UNUSED_0x800) == 0) {
+        gPlayers[arg0].kartProps |= (UNUSED_0x2000 | UNUSED_0x400);
         gPlayers[arg0].type &= ~PLAYER_START_SEQUENCE;
     }
 }

--- a/src/effects.c
+++ b/src/effects.c
@@ -470,7 +470,7 @@ void func_8008D170(Player* player, s8 playerIndex) {
         var_v1 = 0;
         var_a3 = -var_a3;
         var_f0 *= 0.9;
-        if (((player->effects & BRAKING_EFFECT) == BRAKING_EFFECT) || !(player->kartProps & PRESS_A)) {
+        if (((player->effects & BRAKING_EFFECT) == BRAKING_EFFECT) || !(player->kartProps & THROTTLE)) {
             player->effects |= BANANA_SPINOUT_SAVE_EFFECT;
         }
         if (var_f0 <= 1.3) {

--- a/src/effects.c
+++ b/src/effects.c
@@ -612,7 +612,7 @@ void func_8008D760(Player* player) {
     player->rotation[1] = player->unk_0AE;
     player->effects &= ~UNKNOWN_EFFECT_0x80000;
     player->kartGravity = gKartGravityTable[player->characterId];
-    player->type &= 0xFF7F;
+    player->type &= ~PLAYER_UNKNOWN_0x80;
 }
 
 void func_8008D7B0(Player* player, s8 playerIndex) {
@@ -716,7 +716,7 @@ void trigger_squish(Player* player, s8 playerIndex) {
         }
 
         player->effects |= SQUISH_EFFECT;
-        if (((player->type) & 0x1000) != 0) {
+        if (((player->type) & PLAYER_CPU) != 0) {
             play_cpu_sound_effect(playerIndex, player);
         }
     }
@@ -961,7 +961,7 @@ void func_8008E4A4(Player* player, s8 playerIndex) {
         D_80165190[2][playerIndex] = 1;
         D_80165190[3][playerIndex] = 1;
         player->unk_042 = 0;
-        player->type &= ~0x80;
+        player->type &= ~PLAYER_UNKNOWN_0x80;
 
         if ((gIsPlayerTripleAButtonCombo[playerIndex] == true) && ((player->type & PLAYER_HUMAN) == PLAYER_HUMAN)) {
             player->currentSpeed += 100.0f;
@@ -991,7 +991,7 @@ void func_8008E4A4(Player* player, s8 playerIndex) {
                     player->currentSpeed += 100.0f;
                 }
 
-                player->type &= ~0x80;
+                player->type &= ~PLAYER_UNKNOWN_0x80;
             }
         }
     }
@@ -1270,7 +1270,7 @@ void func_8008F1B8(Player* player, s8 arg1) {
             temp = ((u16) D_8018D920[arg1] / 182);
             if (temp == 180) {
                 player->effects &= ~EARLY_START_SPINOUT_EFFECT;
-                player->type &= ~0x80;
+                player->type &= ~PLAYER_UNKNOWN_0x80;
                 player->currentSpeed /= 3.0f;
             }
         } else {
@@ -1280,7 +1280,7 @@ void func_8008F1B8(Player* player, s8 arg1) {
             temp = ((u16) D_8018D920[arg1] / 182);
             if (temp == 180) {
                 player->effects &= ~EARLY_START_SPINOUT_EFFECT;
-                player->type &= ~0x80;
+                player->type &= ~PLAYER_UNKNOWN_0x80;
                 player->currentSpeed /= 3.0f;
             }
         }
@@ -1449,7 +1449,7 @@ void apply_boo_effect(Player* player, s8 playerIndex) {
             player->alpha = ALPHA_MAX;
             gPlayerOtherScreensAlpha[playerIndex] = ALPHA_MAX;
             player->effects &= ~BOO_EFFECT;
-            if ((player->type & 0x4000) != 0) {
+            if ((player->type & PLAYER_HUMAN) != 0) {
                 func_800CB064(playerIndex);
             }
         }
@@ -1459,7 +1459,7 @@ void apply_boo_effect(Player* player, s8 playerIndex) {
             gPlayerOtherScreensAlpha[playerIndex] = ALPHA_MAX;
             player->alpha = ALPHA_MAX;
             player->effects &= ~BOO_EFFECT;
-            if ((player->type & 0x4000) != 0) {
+            if ((player->type & PLAYER_HUMAN) != 0) {
                 func_800CB064(playerIndex);
             }
         }
@@ -1498,7 +1498,7 @@ void func_8008FB30(Player* player, s8 playerIndex) {
         gPlayerOtherScreensAlpha[playerIndex] = ALPHA_MAX;
 
         player->effects &= ~BOO_EFFECT;
-        if ((player->type & 0x4000) != 0) {
+        if ((player->type & PLAYER_HUMAN) != 0) {
             func_800CB064(playerIndex);
         }
     }
@@ -1508,7 +1508,7 @@ void func_8008FB30(Player* player, s8 playerIndex) {
         gPlayerOtherScreensAlpha[playerIndex] = ALPHA_MAX;
         player->alpha = ALPHA_MAX;
         player->effects &= ~BOO_EFFECT;
-        if ((player->type & 0x4000) != 0) {
+        if ((player->type & PLAYER_HUMAN) != 0) {
             func_800CB064(playerIndex);
         }
     }
@@ -1519,7 +1519,7 @@ void func_8008FC1C(Player* player) {
 
     if ((player->type & PLAYER_UNKNOWN_0x40) != 0) {
         playerIndex = get_player_index_for_player(player);
-        player->type = 0x7000;
+        player->type = (PLAYER_HUMAN | PLAYER_START_SEQUENCE | PLAYER_CPU);
         func_80056A94(playerIndex);
     }
 }
@@ -1876,7 +1876,7 @@ void func_80090970(Player* player, s8 playerId, s8 arg2) {
             }
             break;
         case 1:
-            if (((player->type & PLAYER_HUMAN) == 0x4000) && ((player->type & PLAYER_CPU) == 0)) {
+            if (((player->type & PLAYER_HUMAN) == PLAYER_HUMAN) && ((player->type & PLAYER_CPU) == 0)) {
                 func_8009E088(playerId, 0xA);
             }
             if ((player->unk_0CA & UNK_0CA_LAKITU_RETRIEVAL) == UNK_0CA_LAKITU_RETRIEVAL) {
@@ -2107,6 +2107,6 @@ void func_80091298(Player* player, s8 arg1) {
 void func_80091440(s8 arg0) {
     if ((gPlayers[arg0].unk_044 & UNK_044_UNUSED_0x800) == 0) {
         gPlayers[arg0].unk_044 |= (UNK_044_UNUSED_0x2000 | UNK_044_UNUSED_0x400);
-        gPlayers[arg0].type &= ~0x2000;
+        gPlayers[arg0].type &= ~PLAYER_START_SEQUENCE;
     }
 }

--- a/src/effects.c
+++ b/src/effects.c
@@ -313,7 +313,7 @@ void func_8008C8C4(Player* player, s8 playerId) {
         player->currentSpeed = (f32) (player->currentSpeed + 100.0f);
     }
     if ((gModeSelection == VERSUS) && ((player->type & PLAYER_CPU) == PLAYER_CPU) && (!gDemoMode) &&
-        ((player->unk_0CA & 2) == 0) && (gGPCurrentRaceRankByPlayerId[playerId] != 0)) {
+        ((player->unk_0CA & UNK_0CA_HELD_BY_LAKITU) == 0) && (gGPCurrentRaceRankByPlayerId[playerId] != 0)) {
         player->triggers = (s32) (player->triggers | VERTICAL_TUMBLE_TRIGGER);
     }
 }
@@ -1346,7 +1346,7 @@ void func_8008F494(Player* player, s8 playerIndex) {
     player->unk_042 = 0;
 
     if (((player->type & PLAYER_HUMAN) != 0) && ((player->type & PLAYER_INVISIBLE_OR_BOMB) == 0) &&
-        ((player->unk_0CA & 2) == 0) && ((player->unk_0DE & 1) == 0) && ((player->unk_0DE & 2) == 0)) {
+        ((player->unk_0CA & UNK_0CA_HELD_BY_LAKITU) == 0) && ((player->unk_0DE & 1) == 0) && ((player->unk_0DE & 2) == 0)) {
         func_800C90F4(playerIndex, (player->characterId * 0x10) + 0x29008004);
     }
 }
@@ -1773,7 +1773,7 @@ void func_80090778(Player* player) {
     player->unk_078 = 0;
     player->unk_07C = 0;
     player->unk_0C0 = 0;
-    player->unk_0CA |= 8;
+    player->unk_0CA |= UNK_0CA_LAKITU_SCENE;
     player->effects &= ~DRIFTING_EFFECT;
     player->unk_222 = 0;
     player->unk_08C = 0.0f;
@@ -1806,24 +1806,25 @@ void func_80090868(Player* player) {
     player->unk_08C = 0.0f;
     playerIndex = get_player_index_for_player(player);
 
-    if ((player->unk_0CA & 2) != 2) {
+    if ((player->unk_0CA & UNK_0CA_HELD_BY_LAKITU) != UNK_0CA_HELD_BY_LAKITU) {
         player->unk_D98 = 1;
         player->unk_D9C = 0.0f;
         player->unk_DA0 = 0.5f;
         course_update_path_point(player, playerIndex);
         player->unk_222 = 0;
-        player->unk_0CA |= 2;
+        player->unk_0CA |= UNK_0CA_HELD_BY_LAKITU;
         player->unk_0C8 = 0;
         if ((player->unk_0DE & 1) == 1) {
             if ((gCurrentCourseId == COURSE_BOWSER_CASTLE) || (gCurrentCourseId == COURSE_BIG_DONUT)) {
-                player->unk_0CA |= 0x1000;
+                player->unk_0CA |= UNK_0CA_LAKITU_LAVA;
             } else {
-                player->unk_0CA |= 0x2000;
+                player->unk_0CA |= UNK_0CA_LAKITU_WATER;
             }
-
+            // removing the water effect for Sherbet Land makes sense. Perhaps rainbow road and skyscraper
+            // had lave instead of an abyss initially?
             if ((gCurrentCourseId == COURSE_SHERBET_LAND) || (gCurrentCourseId == COURSE_SKYSCRAPER) ||
                 (gCurrentCourseId == COURSE_RAINBOW_ROAD)) {
-                player->unk_0CA &= ~0x3000;
+                player->unk_0CA &= ~(UNK_0CA_LAKITU_LAVA | UNK_0CA_LAKITU_WATER);
             }
         }
     }
@@ -1846,8 +1847,8 @@ void func_80090970(Player* player, s8 playerId, s8 arg2) {
     clean_effect(player, playerId);
     switch (player->unk_222) {
         case 0:
-            if ((player->unk_0CA & 1) == 1) {
-                if ((player->unk_0C8 < 0x3C) || ((player->unk_0CA & 2) != 2)) {
+            if ((player->unk_0CA & UNK_0CA_LAKITU_RETRIEVAL) == UNK_0CA_LAKITU_RETRIEVAL) {
+                if ((player->unk_0C8 < 0x3C) || ((player->unk_0CA & UNK_0CA_HELD_BY_LAKITU) != UNK_0CA_HELD_BY_LAKITU)) {
                     player->unk_0C8++;
                     if (player->unk_0C8 >= 0x3C) {
                         player->unk_0C8 = 0x003C;
@@ -1857,16 +1858,16 @@ void func_80090970(Player* player, s8 playerId, s8 arg2) {
                     move_s16_towards(&player->unk_0CC[arg2], 0, 0.2f);
                     if ((D_801652A0[playerId] + 40.0f) <= player->pos[1]) {
                         player->unk_222 = 1;
-                        player->unk_0CA |= 4;
+                        player->unk_0CA |= UNK_0CA_LAKITU_FIZZLE;
                         player->alpha = 0x00FF;
                     }
                 }
-            } else if ((player->unk_0CA & 2) == 2) {
+            } else if ((player->unk_0CA & UNK_0CA_HELD_BY_LAKITU) == UNK_0CA_HELD_BY_LAKITU) {
                 move_f32_towards(&player->pos[1], player->unk_074 + 100.0f, 0.025f);
                 move_s16_towards(&player->unk_0CC[arg2], 0, 0.2f);
                 if ((player->unk_074 + 40.0f) <= player->pos[1]) {
                     player->unk_222 = 1;
-                    player->unk_0CA |= 4;
+                    player->unk_0CA |= UNK_0CA_LAKITU_FIZZLE;
                     player->alpha = 0x00FF;
                 }
             }
@@ -1878,13 +1879,13 @@ void func_80090970(Player* player, s8 playerId, s8 arg2) {
             if (((player->type & PLAYER_HUMAN) == 0x4000) && ((player->type & PLAYER_CPU) == 0)) {
                 func_8009E088(playerId, 0xA);
             }
-            if ((player->unk_0CA & 1) == 1) {
+            if ((player->unk_0CA & UNK_0CA_LAKITU_RETRIEVAL) == UNK_0CA_LAKITU_RETRIEVAL) {
                 move_f32_towards(&player->pos[1], D_801652A0[playerId] + 40.0f, 0.02f);
                 player->alpha -= 8;
                 if (player->alpha < 9) {
                     player->alpha = 0;
                     player->unk_222 = 2;
-                    player->unk_0CA &= ~0x0001;
+                    player->unk_0CA &= ~UNK_0CA_LAKITU_RETRIEVAL;
                 }
             } else {
                 move_f32_towards(&player->pos[1], player->oldPos[1] + 40.0f, 0.02f);
@@ -1894,7 +1895,7 @@ void func_80090970(Player* player, s8 playerId, s8 arg2) {
                     player->unk_222 = 2;
                 }
             }
-            player->unk_0CA &= ~0x2000;
+            player->unk_0CA &= ~UNK_0CA_LAKITU_WATER;
             break;
         case 2:
             func_80090178(player, playerId, sp44, sp38);
@@ -1920,7 +1921,7 @@ void func_80090970(Player* player, s8 playerId, s8 arg2) {
             if (player->alpha >= 0xF0) {
                 player->alpha = 0x00FF;
                 player->unk_222 = 4;
-                player->unk_0CA &= ~0x0004;
+                player->unk_0CA &= ~UNK_0CA_LAKITU_FIZZLE;
                 player->unk_0C8 = 0;
             }
             break;
@@ -1938,7 +1939,7 @@ void func_80090970(Player* player, s8 playerId, s8 arg2) {
             move_f32_towards(&player->pos[1], (player->unk_074 + player->boundingBoxSize) - 2.0f, 0.04f);
             player->unk_0C8++;
             if (((player->effects & MIDAIR_EFFECT) != MIDAIR_EFFECT) || (player->effects & ENEMY_BONK_EFFECT)) {
-                player->unk_0CA &= ~0x1000;
+                player->unk_0CA &= ~UNK_0CA_LAKITU_LAVA;
                 if (player->unk_0C8 >= 0x5B) {
                     if (player->type & PLAYER_HUMAN) {
                         func_800C9018(playerId, SOUND_ARG_LOAD(0x01, 0x00, 0xFA, 0x28));
@@ -1946,10 +1947,10 @@ void func_80090970(Player* player, s8 playerId, s8 arg2) {
                     if (gModeSelection == BATTLE) {
                         pop_player_balloon(player, playerId);
                     }
-                    player->unk_0CA &= ~0x0002;
+                    player->unk_0CA &= ~UNK_0CA_HELD_BY_LAKITU;
                     player->unk_0DE &= ~0x0004;
-                    if ((player->unk_0CA & 0x80) != 0x80) {
-                        player->unk_0CA &= ~0x0008;
+                    if ((player->unk_0CA & UNK_0CA_FROZEN_EFFECT) != UNK_0CA_FROZEN_EFFECT) {
+                        player->unk_0CA &= ~UNK_0CA_LAKITU_SCENE;
                         if ((player->topSpeed * 0.9) <= player->currentSpeed) {
                             func_8008F104(player, playerId);
                         }
@@ -1986,7 +1987,7 @@ void func_80090970(Player* player, s8 playerId, s8 arg2) {
 
 bool prevent_item_use(Player* player) {
     s32 phi_v0 = 0;
-    if ((((((player->unk_0CA & 2) == 2) || ((player->unk_0CA & 8) == 8)) ||
+    if ((((((player->unk_0CA & UNK_0CA_HELD_BY_LAKITU) == UNK_0CA_HELD_BY_LAKITU) || ((player->unk_0CA & UNK_0CA_LAKITU_SCENE) == UNK_0CA_LAKITU_SCENE)) ||
           ((player->type & PLAYER_UNKNOWN_0x40) != 0)) ||
          ((player->type & PLAYER_CINEMATIC_MODE) != 0)) ||
         ((player->type & PLAYER_EXISTS) == 0)) {

--- a/src/kart_dma.c
+++ b/src/kart_dma.c
@@ -1191,7 +1191,7 @@ void load_kart_texture(Player* player, s8 playerId, s8 screenId, s8 screenId2, s
         ((temp & DRIVING_SPINOUT_EFFECT) == DRIVING_SPINOUT_EFFECT) ||
         ((temp & UNKNOWN_EFFECT_0x80000) == UNKNOWN_EFFECT_0x80000) ||
         ((temp & UNKNOWN_EFFECT_0x800000) == UNKNOWN_EFFECT_0x800000) ||
-        ((temp & LIGHTNING_STRIKE_EFFECT) == LIGHTNING_STRIKE_EFFECT) || ((player->unk_044 & UNK_044_UNUSED_0x800) != 0)) {
+        ((temp & LIGHTNING_STRIKE_EFFECT) == LIGHTNING_STRIKE_EFFECT) || ((player->kartProps & UNUSED_0x800) != 0)) {
         if (player->animFrameSelector[screenId] != 0) {
             osInvalDCache(&gEncodedKartTexture[index][screenId2][playerId], D_800DDEB0[player->characterId]);
 
@@ -1247,7 +1247,7 @@ void load_kart_texture_non_blocking(Player* player, s8 arg1, s8 arg2, s8 arg3, s
         ((temp & DRIVING_SPINOUT_EFFECT) == DRIVING_SPINOUT_EFFECT) ||
         ((temp & UNKNOWN_EFFECT_0x80000) == UNKNOWN_EFFECT_0x80000) ||
         ((temp & UNKNOWN_EFFECT_0x800000) == UNKNOWN_EFFECT_0x800000) ||
-        ((temp & LIGHTNING_STRIKE_EFFECT) == LIGHTNING_STRIKE_EFFECT) || ((player->unk_044 & UNK_044_UNUSED_0x800) != 0)) {
+        ((temp & LIGHTNING_STRIKE_EFFECT) == LIGHTNING_STRIKE_EFFECT) || ((player->kartProps & UNUSED_0x800) != 0)) {
         if (player->animFrameSelector[arg2] != 0) {
             osInvalDCache(&gEncodedKartTexture[arg4][arg3][arg1], D_800DDEB0[player->characterId]);
 

--- a/src/kart_dma.c
+++ b/src/kart_dma.c
@@ -1191,7 +1191,7 @@ void load_kart_texture(Player* player, s8 playerId, s8 screenId, s8 screenId2, s
         ((temp & DRIVING_SPINOUT_EFFECT) == DRIVING_SPINOUT_EFFECT) ||
         ((temp & UNKNOWN_EFFECT_0x80000) == UNKNOWN_EFFECT_0x80000) ||
         ((temp & UNKNOWN_EFFECT_0x800000) == UNKNOWN_EFFECT_0x800000) ||
-        ((temp & LIGHTNING_STRIKE_EFFECT) == LIGHTNING_STRIKE_EFFECT) || ((player->unk_044 & 0x800) != 0)) {
+        ((temp & LIGHTNING_STRIKE_EFFECT) == LIGHTNING_STRIKE_EFFECT) || ((player->unk_044 & UNK_044_UNUSED_0x800) != 0)) {
         if (player->animFrameSelector[screenId] != 0) {
             osInvalDCache(&gEncodedKartTexture[index][screenId2][playerId], D_800DDEB0[player->characterId]);
 
@@ -1247,7 +1247,7 @@ void load_kart_texture_non_blocking(Player* player, s8 arg1, s8 arg2, s8 arg3, s
         ((temp & DRIVING_SPINOUT_EFFECT) == DRIVING_SPINOUT_EFFECT) ||
         ((temp & UNKNOWN_EFFECT_0x80000) == UNKNOWN_EFFECT_0x80000) ||
         ((temp & UNKNOWN_EFFECT_0x800000) == UNKNOWN_EFFECT_0x800000) ||
-        ((temp & LIGHTNING_STRIKE_EFFECT) == LIGHTNING_STRIKE_EFFECT) || ((player->unk_044 & 0x800) != 0)) {
+        ((temp & LIGHTNING_STRIKE_EFFECT) == LIGHTNING_STRIKE_EFFECT) || ((player->unk_044 & UNK_044_UNUSED_0x800) != 0)) {
         if (player->animFrameSelector[arg2] != 0) {
             osInvalDCache(&gEncodedKartTexture[arg4][arg3][arg1], D_800DDEB0[player->characterId]);
 

--- a/src/math_util_2.h
+++ b/src/math_util_2.h
@@ -79,8 +79,6 @@ void rsp_set_matrix_transformation_inverted_x_y_orientation(Vec3f, Vec3su, f32);
 void rsp_set_matrix_transl_rot_scale(Vec3f, Vec3f, f32);
 void rsp_set_matrix_gObjectList(s32);
 
-#define DEGREES_CONVERSION_FACTOR 182
-
 /* This is where I'd put my static data, if I had any */
 extern s8 D_801658FE;
 

--- a/src/player_controller.c
+++ b/src/player_controller.c
@@ -544,7 +544,7 @@ void func_80028864(Player* player, Camera* camera, s8 playerId, s8 screenId) {
                 ((player->effects & UNKNOWN_EFFECT_0x800000) == UNKNOWN_EFFECT_0x800000) ||
                 ((player->effects & EXPLOSION_CRASH_EFFECT) == EXPLOSION_CRASH_EFFECT) ||
                 ((player->effects & HIT_BY_STAR_EFFECT) == HIT_BY_STAR_EFFECT) ||
-                ((player->effects & LIGHTNING_STRIKE_EFFECT) == LIGHTNING_STRIKE_EFFECT) || (player->unk_044 & 0x800)) {
+                ((player->effects & LIGHTNING_STRIKE_EFFECT) == LIGHTNING_STRIKE_EFFECT) || (player->unk_044 & UNK_044_UNUSED_0x800)) {
                 func_8002E594(player, camera, screenId, playerId);
             } else {
                 func_8002D268(player, camera, screenId, playerId);
@@ -577,7 +577,7 @@ void func_80028C44(Player* player, Camera* camera, s8 playerId, s8 screenId) {
             ((player->effects & EXPLOSION_CRASH_EFFECT) == EXPLOSION_CRASH_EFFECT) ||
             ((player->effects & HIT_BY_STAR_EFFECT) == HIT_BY_STAR_EFFECT) ||
             ((player->effects & LIGHTNING_STRIKE_EFFECT) == LIGHTNING_STRIKE_EFFECT) ||
-            ((player->unk_044 & 0x800) != 0)) {
+            ((player->unk_044 & UNK_044_UNUSED_0x800) != 0)) {
             func_8002E594(player, camera, screenId, playerId);
         } else {
             func_8002D268(player, camera, screenId, playerId);
@@ -603,7 +603,7 @@ void func_80028D3C(Player* player, Camera* camera, s8 playerId, s8 screenId) {
             ((player->effects & EXPLOSION_CRASH_EFFECT) == EXPLOSION_CRASH_EFFECT) ||
             ((player->effects & HIT_BY_STAR_EFFECT) == HIT_BY_STAR_EFFECT) ||
             ((player->effects & LIGHTNING_STRIKE_EFFECT) == LIGHTNING_STRIKE_EFFECT) ||
-            ((player->unk_044 & 0x800) != 0)) {
+            ((player->unk_044 & UNK_044_UNUSED_0x800) != 0)) {
             func_8002E594(player, camera, screenId, playerId);
         } else {
             func_8002D268(player, camera, screenId, playerId);
@@ -775,7 +775,7 @@ void func_8002934C(Player* player, Camera* camera, s8 screenId, s8 playerId) {
         ((player->effects & DRIVING_SPINOUT_EFFECT) != DRIVING_SPINOUT_EFFECT) &&
         ((player->effects & UNKNOWN_EFFECT_0x80000) != UNKNOWN_EFFECT_0x80000) &&
         ((player->effects & UNKNOWN_EFFECT_0x800000) != UNKNOWN_EFFECT_0x800000) &&
-        ((player->effects & LIGHTNING_STRIKE_EFFECT) != LIGHTNING_STRIKE_EFFECT) && (!(player->unk_044 & 0x800))) {
+        ((player->effects & LIGHTNING_STRIKE_EFFECT) != LIGHTNING_STRIKE_EFFECT) && (!(player->unk_044 & UNK_044_UNUSED_0x800))) {
         if (var_a0 < 0x51) {
             var_a1 = 0x208;
             var_t0 = 0;
@@ -788,7 +788,7 @@ void func_8002934C(Player* player, Camera* camera, s8 screenId, s8 playerId) {
         var_t0 = 0;
     }
     if (((player->effects & UNKNOWN_EFFECT_0x80000) == UNKNOWN_EFFECT_0x80000) ||
-        ((player->effects & UNKNOWN_EFFECT_0x800000) == UNKNOWN_EFFECT_0x800000) || (player->unk_044 & 0x800)) {
+        ((player->effects & UNKNOWN_EFFECT_0x800000) == UNKNOWN_EFFECT_0x800000) || (player->unk_044 & UNK_044_UNUSED_0x800)) {
         player->unk_050[screenId] = 0;
     }
     if (((player->effects & MIDAIR_EFFECT) == MIDAIR_EFFECT) && ((player->unk_0CA & 2) == 2)) {
@@ -799,7 +799,7 @@ void func_8002934C(Player* player, Camera* camera, s8 screenId, s8 playerId) {
         ((player->effects & DRIVING_SPINOUT_EFFECT) == DRIVING_SPINOUT_EFFECT) ||
         ((player->effects & UNKNOWN_EFFECT_0x80000) == UNKNOWN_EFFECT_0x80000) ||
         ((player->effects & UNKNOWN_EFFECT_0x800000) == UNKNOWN_EFFECT_0x800000) ||
-        ((player->effects & LIGHTNING_STRIKE_EFFECT) == LIGHTNING_STRIKE_EFFECT) || (player->unk_044 & 0x800)) {
+        ((player->effects & LIGHTNING_STRIKE_EFFECT) == LIGHTNING_STRIKE_EFFECT) || (player->unk_044 & UNK_044_UNUSED_0x800)) {
         if (var_a0 >= 0x7FF9) {
             var_a0 = -var_a0;
             var_a0 /= var_a1;
@@ -821,7 +821,7 @@ void func_8002934C(Player* player, Camera* camera, s8 screenId, s8 playerId) {
     }
     if ((player->effects & BANANA_SPINOUT_EFFECT) || (player->effects & DRIVING_SPINOUT_EFFECT) ||
         (player->effects & UNKNOWN_EFFECT_0x80000) || (player->effects & UNKNOWN_EFFECT_0x800000) ||
-        (player->effects & LIGHTNING_STRIKE_EFFECT) || (player->unk_044 & 0x800)) {
+        (player->effects & LIGHTNING_STRIKE_EFFECT) || (player->unk_044 & UNK_044_UNUSED_0x800)) {
 
         if ((player->animFrameSelector[screenId]) >= 0x14) {
             player->animFrameSelector[screenId] = 0;
@@ -831,7 +831,7 @@ void func_8002934C(Player* player, Camera* camera, s8 screenId, s8 playerId) {
         player->animGroupSelector[screenId] = 4;
     }
     if (((player->effects & UNKNOWN_EFFECT_0x80000) == UNKNOWN_EFFECT_0x80000) ||
-        ((player->effects & UNKNOWN_EFFECT_0x800000) == UNKNOWN_EFFECT_0x800000) || (player->unk_044 & 0x800)) {
+        ((player->effects & UNKNOWN_EFFECT_0x800000) == UNKNOWN_EFFECT_0x800000) || (player->unk_044 & UNK_044_UNUSED_0x800)) {
 
         player->animGroupSelector[screenId] = 4;
     }
@@ -1265,7 +1265,7 @@ void func_8002AB70(Player* player) {
     if (player->effects & UNKNOWN_EFFECT_0x80000) {
         player->kartGravity = 1500.0f;
     }
-    if ((player->unk_044 & 0x800) != 0) {
+    if ((player->unk_044 & UNK_044_UNUSED_0x800) != 0) {
         player->kartGravity = 1900.0f;
     }
     if ((player->effects & UNKNOWN_EFFECT_0x800000) == UNKNOWN_EFFECT_0x800000) {
@@ -1299,7 +1299,7 @@ void func_8002AE38(Player* player, s8 arg1, f32 arg2, f32 arg3, f32 arg4, f32 ar
     sp28 = (sins(-player->rotation[1]) * player->speed) + arg2;
     temp_f16 = (coss(-player->rotation[1]) * player->speed) + arg3;
     if (((player->effects & BANANA_NEAR_SPINOUT_EFFECT) != BANANA_NEAR_SPINOUT_EFFECT) &&
-        ((player->effects & DRIFTING_EFFECT) != DRIFTING_EFFECT) && !(player->unk_044 & 0x4000) &&
+        ((player->effects & DRIFTING_EFFECT) != DRIFTING_EFFECT) && !(player->unk_044 & UNK_044_DRIVING_SPINOUT) &&
         ((((player->speed / 18.0f) * 216.0f) <= 8.0f) ||
          (((player->unk_07C >> 0x10) < 5) && ((player->unk_07C >> 0x10) > -5)))) {
         if ((player->effects & AB_SPIN_EFFECT) == AB_SPIN_EFFECT) {
@@ -1441,7 +1441,7 @@ void func_8002B5C0(Player* player, UNUSED s8 playerId, UNUSED s8 screenId) {
     if ((player->effects & BANANA_NEAR_SPINOUT_EFFECT) == BANANA_NEAR_SPINOUT_EFFECT) {
         player->triggers &= ALL_TRIGGERS & ~(ANY_BOOST_TRIGGERS | RACING_SPINOUT_TRIGGERS | STATE_TRANSITION_TRIGGERS);
     }
-    if ((player->unk_044 & 0x4000) != 0) {
+    if ((player->unk_044 & UNK_044_DRIVING_SPINOUT) != 0) {
         player->triggers &= ALL_TRIGGERS & ~(ANY_BOOST_TRIGGERS | RACING_SPINOUT_TRIGGERS | STATE_TRANSITION_TRIGGERS);
     }
     //unclear
@@ -1501,7 +1501,7 @@ void func_8002B830(Player* player, s8 playerId, s8 screenId) {
     if (player->triggers != 0) {
         apply_triggers(player, playerId, screenId);
     }
-    if ((player->unk_044 & 0x400) != 0) { //can never be true
+    if ((player->unk_044 & UNK_044_UNUSED_0x400) != 0) { //can never be true
         func_800911B4(player, playerId);
     }
 }
@@ -1859,7 +1859,7 @@ void func_8002C7E4(Player* player, s8 playerIndex, s8 arg2) {
             if ((player->effects & MUSHROOM_EFFECT) != MUSHROOM_EFFECT) {
                 func_8002B9CC(player, playerIndex, arg2);
             }
-            player->unk_044 &= ~0x0001;
+            player->unk_044 &= ~UNK_044_BACK_UP;
             player->unk_046 |= 1;
             player->unk_046 |= 8;
             if ((player->type & PLAYER_HUMAN) == PLAYER_HUMAN) {
@@ -1879,7 +1879,7 @@ void func_8002C7E4(Player* player, s8 playerIndex, s8 arg2) {
     if ((player->effects & ENEMY_BONK_EFFECT) == ENEMY_BONK_EFFECT) {
         player->effects &= ~ENEMY_BONK_EFFECT;
         player->unk_10C = 1;
-        player->unk_044 &= ~0x0001;
+        player->unk_044 &= ~UNK_044_BACK_UP;
         return;
     }
     player->unk_046 &= ~0x0001;
@@ -1960,7 +1960,7 @@ void apply_effect(Player* player, s8 playerIndex, s8 arg2) {
     if ((player->effects & BANANA_NEAR_SPINOUT_EFFECT) == BANANA_NEAR_SPINOUT_EFFECT) {
         func_8008CEB0(player, playerIndex);
     }
-    if (player->unk_044 & 0x4000) {
+    if (player->unk_044 & UNK_044_DRIVING_SPINOUT) {
         func_8008D170(player, playerIndex);
     }
     if ((player->effects & MUSHROOM_EFFECT) == MUSHROOM_EFFECT) {
@@ -2021,7 +2021,7 @@ void apply_effect(Player* player, s8 playerIndex, s8 arg2) {
             func_8008FCDC(player, playerIndex);
         }
     }
-    if (player->unk_044 & 0x800) { // never true
+    if (player->unk_044 & UNK_044_UNUSED_0x800) { // never true
         func_80091298(player, playerIndex);
     }
 }
@@ -2125,7 +2125,7 @@ void func_8002D268(Player* player, UNUSED Camera* camera, s8 screenId, s8 player
     func_80037BB4(player, sp160);
     func_8002AB70(player);
     func_8002FCA8(player, playerId);
-    if (player->unk_044 & 1) {
+    if (player->unk_044 & UNK_044_BACK_UP) {
         player->unk_064[0] *= -1.0f;
         player->unk_064[2] *= -1.0f;
     }
@@ -2162,7 +2162,7 @@ void func_8002D268(Player* player, UNUSED Camera* camera, s8 screenId, s8 player
     if (temp_f2_2 > 0.1) {
         player->unk_044 |= UNK_044_MOVE_BACKWARDS;
     } else {
-        player->unk_044 &= 0xFFF7;
+        player->unk_044 &= ~UNK_044_MOVE_BACKWARDS;
     }
     if (((player->unk_08C <= 0.0f) &&
          ((temp_v0_3 = player->effects, (temp_v0_3 & BRAKING_EFFECT) == BRAKING_EFFECT))) &&
@@ -2225,8 +2225,8 @@ void func_8002D268(Player* player, UNUSED Camera* camera, s8 screenId, s8 player
         newVelocity[1] = 0.0f;
         newVelocity[2] = 0.0f;
     }
-    if ((player->unk_044 & 0x10) == 0x10) {
-        player->unk_044 &= 0xFFEF;
+    if ((player->unk_044 & UNK_044_LOSE_GP_RACE) == UNK_044_LOSE_GP_RACE) {
+        player->unk_044 &= ~UNK_044_LOSE_GP_RACE;
     }
 
     posX = player->pos[0];
@@ -2252,7 +2252,7 @@ void func_8002D268(Player* player, UNUSED Camera* camera, s8 screenId, s8 player
     player->unk_058 = 0.0f;
     player->unk_060 = 0.0f;
     player->unk_05C = 1.0f;
-    if ((player->unk_044 & 1) != 1) {
+    if ((player->unk_044 & UNK_044_BACK_UP) != UNK_044_BACK_UP) {
         calculate_orientation_matrix(player->orientationMatrix, player->unk_058, player->unk_05C, player->unk_060,
                                      player->rotation[1]);
     } else {
@@ -2282,7 +2282,7 @@ void func_8002D268(Player* player, UNUSED Camera* camera, s8 screenId, s8 player
                 func_800CADD0((u8) playerId, ((f32) player->unk_0C2) / 35.0f);
             }
             if ((player->type & PLAYER_HUMAN) == PLAYER_HUMAN) {
-                player->unk_044 |= 0x100;
+                player->unk_044 |= UNK_044_POST_TUMBLE_GAS;
             }
         }
         if (((player->unk_0C2 < 0x23) && (player->unk_0C2 >= 0x1C)) && (((player->speed / 18.0f) * 216.0f) >= 20.0f)) {
@@ -2293,7 +2293,7 @@ void func_8002D268(Player* player, UNUSED Camera* camera, s8 screenId, s8 player
                 func_800CADD0((u8) playerId, ((f32) player->unk_0C2) / 35.0f);
             }
             if ((player->type & PLAYER_HUMAN) == PLAYER_HUMAN) {
-                player->unk_044 |= 0x100;
+                player->unk_044 |= UNK_044_POST_TUMBLE_GAS;
             }
         }
         if (((player->unk_0C2 < 0x1C) && (player->unk_0C2 >= 4)) && (((player->speed / 18.0f) * 216.0f) >= 20.0f)) {
@@ -2390,7 +2390,7 @@ void func_8002D268(Player* player, UNUSED Camera* camera, s8 screenId, s8 player
             player->speed = gKartTopSpeedTable[player->characterId];
         }
     }
-    if ((player->unk_044 & 1) == 1) {
+    if ((player->unk_044 & UNK_044_BACK_UP) == UNK_044_BACK_UP) {
         if (player->speed > 1) {
             temp = 1 / player->speed;
             player->velocity[0] *= temp;
@@ -2450,7 +2450,7 @@ void func_8002E594(Player* player, UNUSED Camera* camera, s8 screenId, s8 player
            ((player->effects & UNKNOWN_EFFECT_0x80000) == UNKNOWN_EFFECT_0x80000)) ||
           ((player->effects & UNKNOWN_EFFECT_0x800000) == UNKNOWN_EFFECT_0x800000)) ||
          ((player->effects & LIGHTNING_STRIKE_EFFECT) == LIGHTNING_STRIKE_EFFECT)) ||
-        (player->unk_044 & 0x800)) {
+        (player->unk_044 & UNK_044_UNUSED_0x800)) {
         sp46 = 1;
     } else {
         sp46 = 0;
@@ -2549,7 +2549,7 @@ void func_8002E594(Player* player, UNUSED Camera* camera, s8 screenId, s8 player
                     func_800CADD0((u8) playerId, ((f32) player->unk_0C2) / 50.0f);
                 }
                 if ((player->type & PLAYER_HUMAN) == PLAYER_HUMAN) {
-                    player->unk_044 |= 0x100;
+                    player->unk_044 |= UNK_044_POST_TUMBLE_GAS;
                 }
             }
             if (((player->unk_0C2 < 0x1C) && (player->unk_0C2 >= 0xA)) &&
@@ -2561,7 +2561,7 @@ void func_8002E594(Player* player, UNUSED Camera* camera, s8 screenId, s8 player
                     func_800CADD0((u8) playerId, ((f32) player->unk_0C2) / 50.0f);
                 }
                 if ((player->type & PLAYER_HUMAN) == PLAYER_HUMAN) {
-                    player->unk_044 |= 0x100;
+                    player->unk_044 |= UNK_044_POST_TUMBLE_GAS;
                 }
             }
             player->unk_0C2 = 0;
@@ -2586,7 +2586,7 @@ void func_8002E594(Player* player, UNUSED Camera* camera, s8 screenId, s8 player
                     player->kartHopJerk = 0.06f;
                     player->kartHopAcceleration = 0.0f;
                     if ((player->type & PLAYER_HUMAN) == PLAYER_HUMAN) {
-                        player->unk_044 |= 0x100;
+                        player->unk_044 |= UNK_044_POST_TUMBLE_GAS;
                     }
                 }
             } else {
@@ -2693,7 +2693,7 @@ void control_cpu_movement(Player* player, UNUSED Camera* camera, s8 screenId, s8
     f32 topSpeedMultiplier;
     f32 nextY;
     player->effects |= LOST_RACE_EFFECT;
-    player->unk_044 |= 0x10;
+    player->unk_044 |= UNK_044_LOSE_GP_RACE;
     nextY = gPlayerPathY[playerId];
     player->unk_204 = 0;
     player->effects &= ~DRIFTING_EFFECT;
@@ -3392,7 +3392,7 @@ void player_decelerate_alternative(Player* player, f32 speed) {
     if ((player->effects & MIDAIR_EFFECT) != MIDAIR_EFFECT) {
         player->unk_08C = (player->currentSpeed * player->currentSpeed) / 25.0f;
     }
-    player->unk_044 &= 0xFFDF;
+    player->unk_044 &= ~UNK_044_PRESS_A;
     // Hacky way to check for START_SPINOUT_TRIGGER
     if ((player->triggers * 8) < 0) {
         func_8008F104(player, player_index);
@@ -3887,18 +3887,18 @@ void func_80033AE0(Player* player, struct Controller* controller, s8 arg2) {
     }
     if ((player->unk_0C0 / 182) < (-5)) {
         player->unk_044 |= UNK_044_LEFT_TURN;
-        player->unk_044 &= 0xFFFD;
+        player->unk_044 &= ~UNK_044_RIGHT_TURN;
         D_801652C0[arg2]++;
     } else if ((player->unk_0C0 / 182) >= 6) {
         player->unk_044 |= UNK_044_RIGHT_TURN;
-        player->unk_044 &= 0xFFFB;
+        player->unk_044 &= ~UNK_044_LEFT_TURN;
         D_801652C0[arg2]++;
     } else {
-        player->unk_044 &= 0xFFF9;
+        player->unk_044 &= ~(UNK_044_LEFT_TURN | UNK_044_RIGHT_TURN);
         D_801652C0[arg2] = 0;
     }
     if (((player->effects & HOP_EFFECT) == HOP_EFFECT) || ((player->effects & DRIFTING_EFFECT) == DRIFTING_EFFECT)) {
-        player->unk_044 &= 0xFFF9;
+        player->unk_044 &= ~(UNK_044_LEFT_TURN | UNK_044_RIGHT_TURN);
     }
     sp2E4 = player->unk_07C;
     temp_v0_3 = get_clamped_stickX_with_deadzone(controller);
@@ -3909,7 +3909,7 @@ void func_80033AE0(Player* player, struct Controller* controller, s8 arg2) {
     sp2D0 = sp2E4 - player->unk_07C;
     sp2D0 = sp2D0 >> 16;
     player->unk_0FA = (s16) sp2D0;
-    if (((sp2D0 >= 0x5A) || (sp2D0 < (-0x59))) && (!(player->unk_044 & 0x4000))) {
+    if (((sp2D0 >= 0x5A) || (sp2D0 < (-0x59))) && (!(player->unk_044 & UNK_044_DRIVING_SPINOUT))) {
         if ((((((!(player->effects & DRIFTING_EFFECT)) && (gCCSelection == CC_150)) && (gModeSelection != BATTLE)) &&
               (!(player->effects & MIDAIR_EFFECT))) &&
              (((player->speed / 18.0f) * 216.0f) >= 40.0f)) &&
@@ -4300,7 +4300,7 @@ void func_80036DB4(Player* player, Vec3f arg1, Vec3f arg2) {
             ((player->effects & HOP_EFFECT) != HOP_EFFECT)) {
             var_f18 = player->unk_208 + ((-(player->speed / 18.0f) * 216.0f) * 3.0f) + (-player->unk_20C * 10.0f);
             sp20 = player->unk_084 * 3.0f;
-        } else if (!(player->effects & BANANA_NEAR_SPINOUT_EFFECT) && !(player->unk_044 & 0x4000)) {
+        } else if (!(player->effects & BANANA_NEAR_SPINOUT_EFFECT) && !(player->unk_044 & UNK_044_DRIVING_SPINOUT)) {
             thing = player->unk_0FA;
             if (thing > 0) {
                 thing *= -1;
@@ -4361,7 +4361,7 @@ void func_800371F4(Player* player, Vec3f arg1, Vec3f arg2) {
             ((player->effects & HOP_EFFECT) != HOP_EFFECT)) {
             var_f18 = player->unk_208 + ((-(player->speed / 18.0f) * 216.0f) * 3.0f) + (-player->unk_20C * 50.0f);
             sp20 = player->unk_084 * 3.0f;
-        } else if (!(player->effects & BANANA_NEAR_SPINOUT_EFFECT) && !(player->unk_044 & 0x4000)) {
+        } else if (!(player->effects & BANANA_NEAR_SPINOUT_EFFECT) && !(player->unk_044 & UNK_044_DRIVING_SPINOUT)) {
             var_v0 = player->unk_0FA;
             if (var_v0 > 0) {
                 var_v0 *= -1;
@@ -4600,7 +4600,7 @@ void func_80037CFC(Player* player, struct Controller* controller, s8 playerIndex
                 player->effects &= ~AB_SPIN_EFFECT;
             }
         }
-        if ((player->unk_044 & 1) != 1) {
+        if ((player->unk_044 & UNK_044_BACK_UP) != UNK_044_BACK_UP) {
             if (controller->button & A_BUTTON) {
                 player_accelerate_alternative(player);
                 detect_triple_a_combo_a_pressed(player);
@@ -4630,7 +4630,7 @@ void func_80037CFC(Player* player, struct Controller* controller, s8 playerIndex
             }
             if ((get_clamped_stickY_with_deadzone(controller) >= -0x1D) || (!(controller->button & B_BUTTON))) {
                 if ((player->unk_044 & UNK_044_BACK_UP) == UNK_044_BACK_UP) {
-                    player->unk_044 &= 0xFFFE;
+                    player->unk_044 &= ~(UNK_044_BACK_UP);
                     player->currentSpeed = 0.0f;
                 }
             }
@@ -4920,8 +4920,8 @@ void func_80038C6C(Player* player, UNUSED Camera* camera, s8 screenId, s8 player
     newVelocity[0] += ((((((sp114[0] + spA4) + spF0[0])) - (newVelocity[0] * (0.12 * (player->kartFriction)))) / 6000.0) / 1);
     newVelocity[2] += ((((((sp114[2] + sp9C) + spF0[2])) - (newVelocity[2] * (0.12 * (player->kartFriction)))) / 6000.0) / 1);
     newVelocity[1] += ((((((sp114[1] + spA0) + spF0[1])) - (newVelocity[1] * (0.12 * (player->kartFriction)))) / 6000.0) / 1);
-    if ((player->unk_044 & 0x10) == 0x10) {
-        player->unk_044 &= 0xFFEF;
+    if ((player->unk_044 & UNK_044_LOSE_GP_RACE) == UNK_044_LOSE_GP_RACE) {
+        player->unk_044 &= ~UNK_044_LOSE_GP_RACE;
     }
 
     posX = player->pos[0];
@@ -5005,7 +5005,7 @@ void func_80038C6C(Player* player, UNUSED Camera* camera, s8 screenId, s8 player
             player->speed = gKartTopSpeedTable[player->characterId];
         }
     }
-    if ((player->unk_044 & 1) == 1) {
+    if ((player->unk_044 & UNK_044_BACK_UP) == UNK_044_BACK_UP) {
         if (player->speed > 1.0f) {
             player->velocity[0] *= 1.0f / player->speed;
             player->velocity[1] *= 1.0f / player->speed;

--- a/src/player_controller.c
+++ b/src/player_controller.c
@@ -3885,11 +3885,11 @@ void func_80033AE0(Player* player, struct Controller* controller, s8 arg2) {
         ((player->effects & ENEMY_BONK_EFFECT) == ENEMY_BONK_EFFECT)) {
         func_80036CB4(player);
     }
-    if ((player->unk_0C0 / 182) < (-5)) {
+    if ((player->unk_0C0 / DEGREES_CONVERSION_FACTOR) < (-5)) {
         player->unk_044 |= UNK_044_LEFT_TURN;
         player->unk_044 &= ~UNK_044_RIGHT_TURN;
         D_801652C0[arg2]++;
-    } else if ((player->unk_0C0 / 182) >= 6) {
+    } else if ((player->unk_0C0 / DEGREES_CONVERSION_FACTOR) > 5) {
         player->unk_044 |= UNK_044_RIGHT_TURN;
         player->unk_044 &= ~UNK_044_LEFT_TURN;
         D_801652C0[arg2]++;

--- a/src/player_controller.c
+++ b/src/player_controller.c
@@ -533,8 +533,8 @@ void func_80028864(Player* player, Camera* camera, s8 playerId, s8 screenId) {
                 break;
         }
         if ((isVisible == 1) || ((player->type & PLAYER_INVISIBLE_OR_BOMB) == PLAYER_INVISIBLE_OR_BOMB) ||
-            (gModeSelection == BATTLE) || ((player->lakitu_props & HELD_BY_LAKITU) != 0) ||
-            (player->lakitu_props & LAKITU_SCENE) ||
+            (gModeSelection == BATTLE) || ((player->lakituProps & HELD_BY_LAKITU) != 0) ||
+            (player->lakituProps & LAKITU_SCENE) ||
             //! @todo make a proper match
             ((*(D_801633F8 + (playerId))) == ((s16) 1U))) {
             player->effects &= ~LOST_RACE_EFFECT;
@@ -591,8 +591,8 @@ void func_80028C44(Player* player, Camera* camera, s8 playerId, s8 screenId) {
 }
 
 void func_80028D3C(Player* player, Camera* camera, s8 playerId, s8 screenId) {
-    if ((((player->type & PLAYER_START_SEQUENCE) == 0) && (D_800DC510 != 5)) || (player->lakitu_props & 2) != 0 ||
-        (player->lakitu_props & LAKITU_SCENE) != 0 ||
+    if ((((player->type & PLAYER_START_SEQUENCE) == 0) && (D_800DC510 != 5)) || (player->lakituProps & 2) != 0 ||
+        (player->lakituProps & LAKITU_SCENE) != 0 ||
         (player->effects & (LIGHTNING_EFFECT | EXPLOSION_CRASH_EFFECT | HIT_BY_STAR_EFFECT | SQUISH_EFFECT |
                             POST_SQUISH_EFFECT | TERRAIN_TUMBLE_EFFECT | 0xC00 | 0xC0)) != 0) {
         player->effects &= ~LOST_RACE_EFFECT;
@@ -796,7 +796,7 @@ void func_8002934C(Player* player, Camera* camera, s8 screenId, s8 playerId) {
         player->unk_050[screenId] = 0;
     }
     if (((player->effects & MIDAIR_EFFECT) == MIDAIR_EFFECT) &&
-        ((player->lakitu_props & HELD_BY_LAKITU) == HELD_BY_LAKITU)) {
+        ((player->lakituProps & HELD_BY_LAKITU) == HELD_BY_LAKITU)) {
         player->unk_050[screenId] = 0;
     }
     var_a0 = (player->unk_048[screenId] + player->rotation[1] + player->unk_0C0);
@@ -954,7 +954,7 @@ void func_80029B4C(Player* player, UNUSED f32 arg1, f32 arg2, UNUSED f32 arg3) {
     temp_f2_3 = ((gCharacterSize[player->characterId] * 18.0f) + 1.0f) * player->size;
     temp_f0_2 = player->unk_23C - player->unk_230;
     player->unk_206 = -atan1s(temp_f0_2 / temp_f2_3);
-    if (((player->lakitu_props & HELD_BY_LAKITU) == HELD_BY_LAKITU) || (player->effects & MIDAIR_EFFECT)) {
+    if (((player->lakituProps & HELD_BY_LAKITU) == HELD_BY_LAKITU) || (player->effects & MIDAIR_EFFECT)) {
         player->unk_206 = 0;
     }
     if ((player->effects & MIDAIR_EFFECT) != MIDAIR_EFFECT) {
@@ -971,7 +971,7 @@ void func_80029B4C(Player* player, UNUSED f32 arg1, f32 arg2, UNUSED f32 arg3) {
         move_s16_towards(&player->slopeAccel, temp_v0, 0.5f);
     }
     if (((player->effects & MIDAIR_EFFECT) == MIDAIR_EFFECT) &&
-        ((player->lakitu_props & HELD_BY_LAKITU) == HELD_BY_LAKITU)) {
+        ((player->lakituProps & HELD_BY_LAKITU) == HELD_BY_LAKITU)) {
         player->slopeAccel = (s16) ((s32) player->unk_D9C);
     }
     player->surfaceType = get_surface_type(player->collision.meshIndexZX) & 0xFF;
@@ -1434,7 +1434,7 @@ void apply_triggers(Player* player, s8 playerId, UNUSED s8 screenId) {
 }
 
 void func_8002B5C0(Player* player, UNUSED s8 playerId, UNUSED s8 screenId) {
-    if (((player->lakitu_props & LAKITU_SCENE) != 0) || ((player->lakitu_props & HELD_BY_LAKITU) != 0)) {
+    if (((player->lakituProps & LAKITU_SCENE) != 0) || ((player->lakituProps & HELD_BY_LAKITU) != 0)) {
         player->triggers &=
             ALL_TRIGGERS & ~(HIT_TRIGGERS | ANY_BOOST_TRIGGERS | RACING_SPINOUT_TRIGGERS | STATE_TRANSITION_TRIGGERS);
     }
@@ -1812,7 +1812,7 @@ void func_8002C17C(Player* player, s8 playerId) {
             } else if (D_80165330[playerId] == 0) {
                 gCopyNearestPathPointByPlayerId[playerId] = gNearestPathPointByPlayerId[playerId];
                 gCopyPathIndexByPlayerId[playerId] = gPathIndexByPlayerId[playerId];
-            } else if (!((player->effects & MIDAIR_EFFECT) || (player->lakitu_props & LAKITU_RETRIEVAL))) {
+            } else if (!((player->effects & MIDAIR_EFFECT) || (player->lakituProps & LAKITU_RETRIEVAL))) {
                 D_80165330[playerId] = 0;
             }
             break;
@@ -1856,16 +1856,16 @@ void func_8002C4F8(Player* player, s8 playerIndex) {
     }
     if ((player->boundingBoxSize < (D_801652A0[playerIndex] - player->pos[1])) &&
         (player->collision.surfaceDistance[2] >= 600.0f)) {
-        player->lakitu_props |= LAKITU_RETRIEVAL;
+        player->lakituProps |= LAKITU_RETRIEVAL;
     }
     if (player->collision.surfaceDistance[2] >= 600.0f) {
-        player->lakitu_props |= WENT_OVER_OOB;
+        player->lakituProps |= WENT_OVER_OOB;
     } else if ((player->effects & MIDAIR_EFFECT) != MIDAIR_EFFECT) {
-        player->lakitu_props &= ~WENT_OVER_OOB;
+        player->lakituProps &= ~WENT_OVER_OOB;
     }
     if ((player->type & PLAYER_CPU) &&
-        ((func_802ABDF4(player->collision.meshIndexZX) != 0) || (player->lakitu_props & LAKITU_RETRIEVAL))) {
-        if (!(player->lakitu_props & HELD_BY_LAKITU) && !(player->lakitu_props & LAKITU_SCENE) &&
+        ((func_802ABDF4(player->collision.meshIndexZX) != 0) || (player->lakituProps & LAKITU_RETRIEVAL))) {
+        if (!(player->lakituProps & HELD_BY_LAKITU) && !(player->lakituProps & LAKITU_SCENE) &&
             !(player->effects & LOST_RACE_EFFECT)) {
             func_80090778(player);
             func_80090868(player);
@@ -1931,7 +1931,7 @@ void func_8002C954(Player* player, s8 playerId, Vec3f velocity) {
          ((((temp_f0 >= 20.0f) || (temp_f0 < (-1.0f))) && ((player->effects & TERRAIN_TUMBLE_EFFECT) == 0)) &&
           (player->effects & MIDAIR_EFFECT)) ||
          ((player->collision.unk34 == 0) && ((player->effects & TERRAIN_TUMBLE_EFFECT) == 0))) &&
-        (((player->lakitu_props & HELD_BY_LAKITU) == 0) || (!(player->lakitu_props & LAKITU_SCENE)))) {
+        (((player->lakituProps & HELD_BY_LAKITU) == 0) || (!(player->lakituProps & LAKITU_SCENE)))) {
         func_8008F494(player, playerId);
     }
     if ((player->unk_046 & 0x20) != 0x20) {
@@ -1979,8 +1979,8 @@ void func_8002C954(Player* player, s8 playerId, Vec3f velocity) {
 }
 
 void apply_effect(Player* player, s8 playerIndex, s8 arg2) {
-    if (((player->lakitu_props & HELD_BY_LAKITU) == HELD_BY_LAKITU) ||
-        ((player->lakitu_props & LAKITU_SCENE) == LAKITU_SCENE)) {
+    if (((player->lakituProps & HELD_BY_LAKITU) == HELD_BY_LAKITU) ||
+        ((player->lakituProps & LAKITU_SCENE) == LAKITU_SCENE)) {
         func_80090970(player, playerIndex, arg2);
     }
     if ((player->effects & BANANA_NEAR_SPINOUT_EFFECT) == BANANA_NEAR_SPINOUT_EFFECT) {
@@ -2244,10 +2244,10 @@ void func_8002D268(Player* player, UNUSED Camera* camera, s8 screenId, s8 player
         (((((f64) ((sp184[1] + gravityY) + sp160[1])) - (newVelocity[1] * (0.12 * ((f64) player->kartFriction)))) /
           6000.0) /
          ((f64) player->unk_DAC));
-    if (((((player->lakitu_props & HELD_BY_LAKITU) == HELD_BY_LAKITU) ||
-          ((player->lakitu_props & LAKITU_SCENE) == LAKITU_SCENE)) ||
+    if (((((player->lakituProps & HELD_BY_LAKITU) == HELD_BY_LAKITU) ||
+          ((player->lakituProps & LAKITU_SCENE) == LAKITU_SCENE)) ||
          ((player->effects & SQUISH_EFFECT) == SQUISH_EFFECT)) ||
-        (player->lakitu_props & LAKITU_RETRIEVAL)) {
+        (player->lakituProps & LAKITU_RETRIEVAL)) {
         newVelocity[0] = 0.0f;
         newVelocity[1] = 0.0f;
         newVelocity[2] = 0.0f;
@@ -2267,10 +2267,10 @@ void func_8002D268(Player* player, UNUSED Camera* camera, s8 screenId, s8 player
     nextY = posY + player->velocity[1];
     nextZ = posZ + player->velocity[2] + D_8018CE10[playerId].unk_04[2];
 
-    if (((((player->lakitu_props & HELD_BY_LAKITU) != HELD_BY_LAKITU) &&
-          ((player->lakitu_props & LAKITU_SCENE) != LAKITU_SCENE)) &&
+    if (((((player->lakituProps & HELD_BY_LAKITU) != HELD_BY_LAKITU) &&
+          ((player->lakituProps & LAKITU_SCENE) != LAKITU_SCENE)) &&
          ((player->effects & SQUISH_EFFECT) != SQUISH_EFFECT)) &&
-        (!(player->lakitu_props & LAKITU_RETRIEVAL))) {
+        (!(player->lakituProps & LAKITU_RETRIEVAL))) {
         func_8002AAC0(player);
         nextY += player->kartHopVelocity;
         nextY -= 0.02;
@@ -2299,7 +2299,7 @@ void func_8002D268(Player* player, UNUSED Camera* camera, s8 screenId, s8 player
             }
             player->unk_DB4.unkC = 3.0f;
             player->unk_DB4.unk18 = 0;
-            player->kart_graphics |= POOMP;
+            player->kartGraphics |= POOMP;
             if ((((player->type & PLAYER_HUMAN) == PLAYER_HUMAN) &&
                  ((player->effects & BOOST_RAMP_ASPHALT_EFFECT) == BOOST_RAMP_ASPHALT_EFFECT)) &&
                 ((player->type & PLAYER_INVISIBLE_OR_BOMB) != PLAYER_INVISIBLE_OR_BOMB)) {
@@ -2368,7 +2368,7 @@ void func_8002D268(Player* player, UNUSED Camera* camera, s8 screenId, s8 player
     }
     if (((!(player->effects & MIDAIR_EFFECT)) && (func_802ABDB8(player->collision.meshIndexZX) != 0)) &&
         ((player->effects & TERRAIN_TUMBLE_EFFECT) != TERRAIN_TUMBLE_EFFECT)) {
-        if ((!(player->lakitu_props & HELD_BY_LAKITU)) || (!(player->lakitu_props & LAKITU_SCENE))) {
+        if ((!(player->lakituProps & HELD_BY_LAKITU)) || (!(player->lakituProps & LAKITU_SCENE))) {
             func_8008F494(player, playerId);
         }
     } else if (((!(player->effects & MIDAIR_EFFECT)) && (func_802ABDB8(player->collision.meshIndexZX) == 0)) &&
@@ -2539,8 +2539,8 @@ void func_8002E594(Player* player, UNUSED Camera* camera, s8 screenId, s8 player
     newVelocity[1] += (((((spEC[1] + gravityY) + spD4[1])) - (newVelocity[1] * (0.12 * player->kartFriction))) / 6000) /
                       player->unk_DAC;
 
-    if (((player->lakitu_props & HELD_BY_LAKITU) == HELD_BY_LAKITU) ||
-        ((player->lakitu_props & LAKITU_SCENE) == LAKITU_SCENE)) {
+    if (((player->lakituProps & HELD_BY_LAKITU) == HELD_BY_LAKITU) ||
+        ((player->lakituProps & LAKITU_SCENE) == LAKITU_SCENE)) {
         newVelocity[0] = 0.0f;
         newVelocity[1] = 0.0f;
         newVelocity[2] = 0.0f;
@@ -2577,7 +2577,7 @@ void func_8002E594(Player* player, UNUSED Camera* camera, s8 screenId, s8 player
                     player->unk_0C2 = 0x0032;
                 }
                 player->unk_DB4.unk18 = 0;
-                player->kart_graphics |= POOMP;
+                player->kartGraphics |= POOMP;
                 player->unk_DB4.unkC = 3.0f;
                 if (((player->type & PLAYER_HUMAN) == PLAYER_HUMAN) &&
                     ((player->type & PLAYER_INVISIBLE_OR_BOMB) != PLAYER_INVISIBLE_OR_BOMB)) {
@@ -2662,7 +2662,7 @@ void func_8002E594(Player* player, UNUSED Camera* camera, s8 screenId, s8 player
     if (((func_802ABDB8(player->collision.meshIndexZX) != 0) &&
          ((player->effects & TERRAIN_TUMBLE_EFFECT) != TERRAIN_TUMBLE_EFFECT)) &&
         (((player->speed / 18.0f) * 216.0f) >= 20.0f)) {
-        if ((!(player->lakitu_props & HELD_BY_LAKITU)) || (!(player->lakitu_props & LAKITU_SCENE))) {
+        if ((!(player->lakituProps & HELD_BY_LAKITU)) || (!(player->lakituProps & LAKITU_SCENE))) {
             func_8008F494(player, playerId);
         }
     } else if (((!(player->effects & MIDAIR_EFFECT)) && (func_802ABDB8(player->collision.meshIndexZX) == 0)) &&
@@ -3017,7 +3017,7 @@ f32 func_80030150(Player* player, s8 playerIndex) {
             }
         }
         if (((player->effects & MIDAIR_EFFECT) != MIDAIR_EFFECT) &&
-            ((player->lakitu_props & HELD_BY_LAKITU) != HELD_BY_LAKITU)) {
+            ((player->lakituProps & HELD_BY_LAKITU) != HELD_BY_LAKITU)) {
             temp_lo = player->slopeAccel / 182;
             if (var_f2 >= 20.0f) {
                 if ((temp_lo > 0x11) || (temp_lo < -0x11)) {
@@ -3108,8 +3108,8 @@ f32 func_80030150(Player* player, s8 playerIndex) {
     if (var_f2 < 0.0f) {
         var_f2 = 0.0f;
     }
-    if (((player->lakitu_props & HELD_BY_LAKITU) == HELD_BY_LAKITU) ||
-        ((player->lakitu_props & LAKITU_SCENE) == LAKITU_SCENE) ||
+    if (((player->lakituProps & HELD_BY_LAKITU) == HELD_BY_LAKITU) ||
+        ((player->lakituProps & LAKITU_SCENE) == LAKITU_SCENE) ||
         ((player->type & PLAYER_START_SEQUENCE) == PLAYER_START_SEQUENCE)) {
         return (1.0f - player->unk_104) * var_f2;
     }
@@ -3133,8 +3133,8 @@ void func_80030A34(Player* player) {
     f32 var_f0;
     f32 var_f2;
 
-    if (((player->lakitu_props & HELD_BY_LAKITU) != HELD_BY_LAKITU) &&
-        ((player->lakitu_props & LAKITU_SCENE) != LAKITU_SCENE)) {
+    if (((player->lakituProps & HELD_BY_LAKITU) != HELD_BY_LAKITU) &&
+        ((player->lakituProps & LAKITU_SCENE) != LAKITU_SCENE)) {
         if ((((player->speed / 18.0f) * 216.0f) >= 8.0f) && (player->unk_DB4.unkC < 1.0f)) {
             switch (player->surfaceType) { /* irregular */
                 case ASPHALT:
@@ -4300,7 +4300,7 @@ void func_80036C5C(Player* player) {
     if (((player->speed / 18.0f) * 216.0f) > 20.0f) {
         player->unk_204 = 0;
         player->effects |= DRIFTING_EFFECT;
-        player->kart_graphics |= BOING;
+        player->kartGraphics |= BOING;
     }
 }
 
@@ -4704,8 +4704,8 @@ void handle_a_press_for_player_during_race(Player* player, struct Controller* co
         ((player->type & PLAYER_CPU) != PLAYER_CPU)) {
         // If not start sequence
         if ((player->type & PLAYER_START_SEQUENCE) != PLAYER_START_SEQUENCE) {
-            if (((player->lakitu_props & HELD_BY_LAKITU) == HELD_BY_LAKITU) ||
-                ((player->lakitu_props & LAKITU_SCENE) == LAKITU_SCENE)) {
+            if (((player->lakituProps & HELD_BY_LAKITU) == HELD_BY_LAKITU) ||
+                ((player->lakituProps & LAKITU_SCENE) == LAKITU_SCENE)) {
                 if (controller->button & A_BUTTON) {
                     player_accelerate(player);
                 } else {

--- a/src/player_controller.c
+++ b/src/player_controller.c
@@ -1501,7 +1501,7 @@ void func_8002B830(Player* player, s8 playerId, s8 screenId) {
     if (player->triggers != 0) {
         apply_triggers(player, playerId, screenId);
     }
-    if ((player->unk_044 & 0x400) != 0) {
+    if ((player->unk_044 & 0x400) != 0) { //can never be true
         func_800911B4(player, playerId);
     }
 }
@@ -2021,7 +2021,7 @@ void apply_effect(Player* player, s8 playerIndex, s8 arg2) {
             func_8008FCDC(player, playerIndex);
         }
     }
-    if (player->unk_044 & 0x800) {
+    if (player->unk_044 & 0x800) { // never true
         func_80091298(player, playerIndex);
     }
 }
@@ -2160,7 +2160,7 @@ void func_8002D268(Player* player, UNUSED Camera* camera, s8 screenId, s8 player
     temp_f2_2 = ((player->oldPos[2] - player->pos[2]) * coss(player->rotation[1] + player->unk_0C0)) +
                 (-(player->oldPos[0] - player->pos[0]) * sins(player->rotation[1] + player->unk_0C0));
     if (temp_f2_2 > 0.1) {
-        player->unk_044 |= 8;
+        player->unk_044 |= UNK_044_MOVE_BACKWARDS;
     } else {
         player->unk_044 &= 0xFFF7;
     }
@@ -3367,7 +3367,7 @@ void player_accelerate_alternative(Player* player) {
     if (!((player->effects & MIDAIR_EFFECT)) || ((player->effects & LIGHTNING_EFFECT))) {
         player->unk_08C = (player->currentSpeed * player->currentSpeed) / 25.0f;
     }
-    player->unk_044 |= 0x20;
+    player->unk_044 |= UNK_044_PRESS_A;
     // Hacky way to check for START_SPINOUT_TRIGGER
     if ((player->triggers * 8) < 0) {
         func_8008F104(player, player_index);
@@ -3635,7 +3635,7 @@ void player_accelerate_during_start_sequence(Player* player) {
         } else {
             var_v0 = 8;
         }
-        if ((time_delta < var_v0) && ((player->unk_044 & 0x20) != 0x20)) {
+        if ((time_delta < var_v0) && ((player->unk_044 & UNK_044_PRESS_A) != UNK_044_PRESS_A)) {
             player->triggers |= START_BOOST_TRIGGER;
         } else if ((player->topSpeed * 0.9f) <= player->currentSpeed) {
             if ((player->triggers & START_BOOST_TRIGGER) != START_BOOST_TRIGGER) {
@@ -3644,7 +3644,7 @@ void player_accelerate_during_start_sequence(Player* player) {
             }
         }
     }
-    player->unk_044 |= 0x20;
+    player->unk_044 |= UNK_044_PRESS_A;
     player->unk_098 = (player->currentSpeed * player->currentSpeed) / 25.0f;
 }
 
@@ -3663,7 +3663,7 @@ void player_decelerate_during_start_sequence(Player* player, f32 speedReduction)
         player->triggers &= ~START_SPINOUT_TRIGGER;
     }
     player->triggers &= ~START_BOOST_TRIGGER;
-    player->unk_044 &= ~0x0020;
+    player->unk_044 &= ~UNK_044_PRESS_A;
     player->unk_098 = (player->currentSpeed * player->currentSpeed) / 25.0f;
 }
 
@@ -3752,7 +3752,7 @@ void player_accelerate_global(Player* player, s32 playerIndex) {
     if (((player->topSpeed * 0.9) <= gPlayerCurrentSpeed[playerIndex]) && (gPlayerCurrentSpeed[playerIndex] <= (player->topSpeed * 1.0))) {
         gPlayerCurrentSpeed[playerIndex] += gKartAccelerationTables[player->characterId][9] * 2.8;
     }
-    player->unk_044 |= 0x20;
+    player->unk_044 |= UNK_044_PRESS_A;
     if (gPlayerCurrentSpeed[playerIndex] < 0.0f) {
         gPlayerCurrentSpeed[playerIndex] = 0.0f;
     }
@@ -3760,7 +3760,7 @@ void player_accelerate_global(Player* player, s32 playerIndex) {
 }
 
 void player_decelerate_global(Player* player, f32 speedReduction, s32 playerIndex) {
-    player->unk_044 &= ~0x20;
+    player->unk_044 &= ~UNK_044_PRESS_A;
     gPlayerCurrentSpeed[playerIndex] -= speedReduction;
     if (gPlayerCurrentSpeed[playerIndex] <= 0.0f) {
         gPlayerCurrentSpeed[playerIndex] = 0.0f;
@@ -3886,11 +3886,11 @@ void func_80033AE0(Player* player, struct Controller* controller, s8 arg2) {
         func_80036CB4(player);
     }
     if ((player->unk_0C0 / 182) < (-5)) {
-        player->unk_044 |= 4;
+        player->unk_044 |= UNK_044_LEFT_TURN;
         player->unk_044 &= 0xFFFD;
         D_801652C0[arg2]++;
     } else if ((player->unk_0C0 / 182) >= 6) {
-        player->unk_044 |= 2;
+        player->unk_044 |= UNK_044_RIGHT_TURN;
         player->unk_044 &= 0xFFFB;
         D_801652C0[arg2]++;
     } else {
@@ -3902,7 +3902,7 @@ void func_80033AE0(Player* player, struct Controller* controller, s8 arg2) {
     }
     sp2E4 = player->unk_07C;
     temp_v0_3 = get_clamped_stickX_with_deadzone(controller);
-    if (((player->unk_044 & 1) == 1) || ((player->unk_044 & 8) == 8)) {
+    if (((player->unk_044 & UNK_044_BACK_UP) == UNK_044_BACK_UP) || ((player->unk_044 & UNK_044_MOVE_BACKWARDS) == UNK_044_MOVE_BACKWARDS)) {
         temp_v0_3 = -temp_v0_3;
     }
     player->unk_07C = (temp_v0_3 << 16) & 0xFFFF0000;
@@ -3934,7 +3934,7 @@ void func_80033AE0(Player* player, struct Controller* controller, s8 arg2) {
             var_a0 = 0;
         }
         if (((player->speed / 18.0f) * 216.0f) >= 15.0f) {
-            if ((player->unk_044 & 2) == 2) {
+            if ((player->unk_044 & UNK_044_RIGHT_TURN) == UNK_044_RIGHT_TURN) {
                 if ((sp2D0 < 36) && (sp2D0 >= 0)) {
                     sp2C8 =
                         (gKartTable800E3650[player->characterId] + 1.0f) * (((f32) (var_a0 + 0xF)) * (1.0f + var_f2));
@@ -3944,7 +3944,7 @@ void func_80033AE0(Player* player, struct Controller* controller, s8 arg2) {
                     sp2C8 = (s32) (((f32) (var_a0 + 5)) * (1.0f + var_f2));
                     sp2CC = (s32) (((f32) (var_a0 + 9)) * (1.0f + var_f2));
                 }
-            } else if ((player->unk_044 & 4) == 4) {
+            } else if ((player->unk_044 & UNK_044_LEFT_TURN) == UNK_044_LEFT_TURN) {
                 if ((sp2D0 >= (-0x23)) && (sp2D0 <= 0)) {
                     sp2C8 =
                         (gKartTable800E3650[player->characterId] + 1.0f) * (((f32) (var_a0 + 0xF)) * (1.0f + var_f2));
@@ -4624,12 +4624,12 @@ void func_80037CFC(Player* player, struct Controller* controller, s8 playerIndex
             if (((get_clamped_stickY_with_deadzone(controller) < (-0x31)) && (((player->speed / 18.0f) * 216.0f) <= 5.0f)) &&
                 (controller->button & B_BUTTON)) {
                 player->currentSpeed = 140.0f;
-                player->unk_044 |= 1;
+                player->unk_044 |= UNK_044_BACK_UP;
                 player->unk_08C = (player->currentSpeed * player->currentSpeed) / 25.0f;
                 player->unk_20C = 0.0f;
             }
             if ((get_clamped_stickY_with_deadzone(controller) >= -0x1D) || (!(controller->button & B_BUTTON))) {
-                if ((player->unk_044 & 1) == 1) {
+                if ((player->unk_044 & UNK_044_BACK_UP) == UNK_044_BACK_UP) {
                     player->unk_044 &= 0xFFFE;
                     player->currentSpeed = 0.0f;
                 }
@@ -4863,7 +4863,7 @@ void func_80038BE4(Player* player, s16 arg1) {
     if (player->currentSpeed >= 250.0f) {
         player->currentSpeed = 250.0f;
     }
-    player->unk_044 |= 0x20;
+    player->unk_044 |= UNK_044_PRESS_A;
     player->unk_08C = (player->currentSpeed * player->currentSpeed) / 25.0f;
 }
 

--- a/src/player_controller.c
+++ b/src/player_controller.c
@@ -2270,7 +2270,7 @@ void func_8002D268(Player* player, UNUSED Camera* camera, s8 screenId, s8 player
             }
             player->unk_DB4.unkC = 3.0f;
             player->unk_DB4.unk18 = 0;
-            player->unk_0B6 |= UNK_0B6_POOMP;
+            player->kart_graphics |= POOMP;
             if ((((player->type & PLAYER_HUMAN) == PLAYER_HUMAN) &&
                  ((player->effects & BOOST_RAMP_ASPHALT_EFFECT) == BOOST_RAMP_ASPHALT_EFFECT)) &&
                 ((player->type & PLAYER_INVISIBLE_OR_BOMB) != PLAYER_INVISIBLE_OR_BOMB)) {
@@ -2541,7 +2541,7 @@ void func_8002E594(Player* player, UNUSED Camera* camera, s8 screenId, s8 player
                     player->unk_0C2 = 0x0032;
                 }
                 player->unk_DB4.unk18 = 0;
-                player->unk_0B6 |= UNK_0B6_POOMP;
+                player->kart_graphics |= POOMP;
                 player->unk_DB4.unkC = 3.0f;
                 if (((player->type & PLAYER_HUMAN) == PLAYER_HUMAN) &&
                     ((player->type & PLAYER_INVISIBLE_OR_BOMB) != PLAYER_INVISIBLE_OR_BOMB)) {
@@ -4258,7 +4258,7 @@ void func_80036C5C(Player* player) {
     if (((player->speed / 18.0f) * 216.0f) > 20.0f) {
         player->unk_204 = 0;
         player->effects |= DRIFTING_EFFECT;
-        player->unk_0B6 |= UNK_0B6_BOING;
+        player->kart_graphics |= BOING;
     }
 }
 

--- a/src/player_controller.c
+++ b/src/player_controller.c
@@ -218,7 +218,8 @@ s32 get_player_index_for_player(Player* player) {
 void func_80027DA8(Player* player, s8 playerId) {
     if (D_8015F890 != 1) {
         if ((player->type & PLAYER_UNKNOWN_0x10) != PLAYER_UNKNOWN_0x10) {
-            if (((D_8018D168 == 1) && ((player->type & PLAYER_HUMAN) == PLAYER_HUMAN)) && ((player->type & PLAYER_INVISIBLE_OR_BOMB) != PLAYER_INVISIBLE_OR_BOMB)) {
+            if (((D_8018D168 == 1) && ((player->type & PLAYER_HUMAN) == PLAYER_HUMAN)) &&
+                ((player->type & PLAYER_INVISIBLE_OR_BOMB) != PLAYER_INVISIBLE_OR_BOMB)) {
                 func_800C94A4(playerId);
                 player->type |= PLAYER_UNKNOWN_0x10;
             } else if ((player->type & PLAYER_START_SEQUENCE) == 0) {
@@ -532,7 +533,8 @@ void func_80028864(Player* player, Camera* camera, s8 playerId, s8 screenId) {
                 break;
         }
         if ((isVisible == 1) || ((player->type & PLAYER_INVISIBLE_OR_BOMB) == PLAYER_INVISIBLE_OR_BOMB) ||
-            (gModeSelection == BATTLE) || ((player->lakitu_props & HELD_BY_LAKITU) != 0) || (player->lakitu_props & LAKITU_SCENE) ||
+            (gModeSelection == BATTLE) || ((player->lakitu_props & HELD_BY_LAKITU) != 0) ||
+            (player->lakitu_props & LAKITU_SCENE) ||
             //! @todo make a proper match
             ((*(D_801633F8 + (playerId))) == ((s16) 1U))) {
             player->effects &= ~LOST_RACE_EFFECT;
@@ -544,7 +546,8 @@ void func_80028864(Player* player, Camera* camera, s8 playerId, s8 screenId) {
                 ((player->effects & UNKNOWN_EFFECT_0x800000) == UNKNOWN_EFFECT_0x800000) ||
                 ((player->effects & EXPLOSION_CRASH_EFFECT) == EXPLOSION_CRASH_EFFECT) ||
                 ((player->effects & HIT_BY_STAR_EFFECT) == HIT_BY_STAR_EFFECT) ||
-                ((player->effects & LIGHTNING_STRIKE_EFFECT) == LIGHTNING_STRIKE_EFFECT) || (player->kartProps & UNUSED_0x800)) {
+                ((player->effects & LIGHTNING_STRIKE_EFFECT) == LIGHTNING_STRIKE_EFFECT) ||
+                (player->kartProps & UNUSED_0x800)) {
                 func_8002E594(player, camera, screenId, playerId);
             } else {
                 func_8002D268(player, camera, screenId, playerId);
@@ -774,7 +777,8 @@ void func_8002934C(Player* player, Camera* camera, s8 screenId, s8 playerId) {
         ((player->effects & DRIVING_SPINOUT_EFFECT) != DRIVING_SPINOUT_EFFECT) &&
         ((player->effects & UNKNOWN_EFFECT_0x80000) != UNKNOWN_EFFECT_0x80000) &&
         ((player->effects & UNKNOWN_EFFECT_0x800000) != UNKNOWN_EFFECT_0x800000) &&
-        ((player->effects & LIGHTNING_STRIKE_EFFECT) != LIGHTNING_STRIKE_EFFECT) && (!(player->kartProps & UNUSED_0x800))) {
+        ((player->effects & LIGHTNING_STRIKE_EFFECT) != LIGHTNING_STRIKE_EFFECT) &&
+        (!(player->kartProps & UNUSED_0x800))) {
         if (var_a0 < 0x51) {
             var_a1 = 0x208;
             var_t0 = 0;
@@ -787,10 +791,12 @@ void func_8002934C(Player* player, Camera* camera, s8 screenId, s8 playerId) {
         var_t0 = 0;
     }
     if (((player->effects & UNKNOWN_EFFECT_0x80000) == UNKNOWN_EFFECT_0x80000) ||
-        ((player->effects & UNKNOWN_EFFECT_0x800000) == UNKNOWN_EFFECT_0x800000) || (player->kartProps & UNUSED_0x800)) {
+        ((player->effects & UNKNOWN_EFFECT_0x800000) == UNKNOWN_EFFECT_0x800000) ||
+        (player->kartProps & UNUSED_0x800)) {
         player->unk_050[screenId] = 0;
     }
-    if (((player->effects & MIDAIR_EFFECT) == MIDAIR_EFFECT) && ((player->lakitu_props & HELD_BY_LAKITU) == HELD_BY_LAKITU)) {
+    if (((player->effects & MIDAIR_EFFECT) == MIDAIR_EFFECT) &&
+        ((player->lakitu_props & HELD_BY_LAKITU) == HELD_BY_LAKITU)) {
         player->unk_050[screenId] = 0;
     }
     var_a0 = (player->unk_048[screenId] + player->rotation[1] + player->unk_0C0);
@@ -798,7 +804,8 @@ void func_8002934C(Player* player, Camera* camera, s8 screenId, s8 playerId) {
         ((player->effects & DRIVING_SPINOUT_EFFECT) == DRIVING_SPINOUT_EFFECT) ||
         ((player->effects & UNKNOWN_EFFECT_0x80000) == UNKNOWN_EFFECT_0x80000) ||
         ((player->effects & UNKNOWN_EFFECT_0x800000) == UNKNOWN_EFFECT_0x800000) ||
-        ((player->effects & LIGHTNING_STRIKE_EFFECT) == LIGHTNING_STRIKE_EFFECT) || (player->kartProps & UNUSED_0x800)) {
+        ((player->effects & LIGHTNING_STRIKE_EFFECT) == LIGHTNING_STRIKE_EFFECT) ||
+        (player->kartProps & UNUSED_0x800)) {
         if (var_a0 >= 0x7FF9) {
             var_a0 = -var_a0;
             var_a0 /= var_a1;
@@ -830,7 +837,8 @@ void func_8002934C(Player* player, Camera* camera, s8 screenId, s8 playerId) {
         player->animGroupSelector[screenId] = 4;
     }
     if (((player->effects & UNKNOWN_EFFECT_0x80000) == UNKNOWN_EFFECT_0x80000) ||
-        ((player->effects & UNKNOWN_EFFECT_0x800000) == UNKNOWN_EFFECT_0x800000) || (player->kartProps & UNUSED_0x800)) {
+        ((player->effects & UNKNOWN_EFFECT_0x800000) == UNKNOWN_EFFECT_0x800000) ||
+        (player->kartProps & UNUSED_0x800)) {
 
         player->animGroupSelector[screenId] = 4;
     }
@@ -962,7 +970,8 @@ void func_80029B4C(Player* player, UNUSED f32 arg1, f32 arg2, UNUSED f32 arg3) {
         }
         move_s16_towards(&player->slopeAccel, temp_v0, 0.5f);
     }
-    if (((player->effects & MIDAIR_EFFECT) == MIDAIR_EFFECT) && ((player->lakitu_props & HELD_BY_LAKITU) == HELD_BY_LAKITU)) {
+    if (((player->effects & MIDAIR_EFFECT) == MIDAIR_EFFECT) &&
+        ((player->lakitu_props & HELD_BY_LAKITU) == HELD_BY_LAKITU)) {
         player->slopeAccel = (s16) ((s32) player->unk_D9C);
     }
     player->surfaceType = get_surface_type(player->collision.meshIndexZX) & 0xFF;
@@ -973,7 +982,8 @@ void func_80029B4C(Player* player, UNUSED f32 arg1, f32 arg2, UNUSED f32 arg3) {
         }
     }
     if (player->surfaceType == BOOST_RAMP_WOOD) {
-        if (((player->effects & BOOST_RAMP_WOOD_EFFECT) != BOOST_RAMP_WOOD_EFFECT) && ((player->effects & MIDAIR_EFFECT) != MIDAIR_EFFECT)) {
+        if (((player->effects & BOOST_RAMP_WOOD_EFFECT) != BOOST_RAMP_WOOD_EFFECT) &&
+            ((player->effects & MIDAIR_EFFECT) != MIDAIR_EFFECT)) {
             player->triggers |= BOOST_RAMP_WOOD_TRIGGER;
         }
     }
@@ -1425,7 +1435,8 @@ void apply_triggers(Player* player, s8 playerId, UNUSED s8 screenId) {
 
 void func_8002B5C0(Player* player, UNUSED s8 playerId, UNUSED s8 screenId) {
     if (((player->lakitu_props & LAKITU_SCENE) != 0) || ((player->lakitu_props & HELD_BY_LAKITU) != 0)) {
-        player->triggers &= ALL_TRIGGERS & ~(HIT_TRIGGERS | ANY_BOOST_TRIGGERS | RACING_SPINOUT_TRIGGERS | STATE_TRANSITION_TRIGGERS);
+        player->triggers &=
+            ALL_TRIGGERS & ~(HIT_TRIGGERS | ANY_BOOST_TRIGGERS | RACING_SPINOUT_TRIGGERS | STATE_TRANSITION_TRIGGERS);
     }
     // Green shell
     if ((player->effects & HIT_BY_GREEN_SHELL_EFFECT) == HIT_BY_GREEN_SHELL_EFFECT) {
@@ -1434,7 +1445,9 @@ void func_8002B5C0(Player* player, UNUSED s8 playerId, UNUSED s8 screenId) {
     // Spinout (banana or driving)
     if (((player->effects & BANANA_SPINOUT_EFFECT) == BANANA_SPINOUT_EFFECT) ||
         ((player->effects & DRIVING_SPINOUT_EFFECT) == DRIVING_SPINOUT_EFFECT)) {
-        player->triggers &= (ALL_TRIGGERS & ~(ANY_BOOST_TRIGGERS | RACING_SPINOUT_TRIGGERS | STATE_TRANSITION_TRIGGERS)) | UNUSED_TRIGGER_0x20000;
+        player->triggers &=
+            (ALL_TRIGGERS & ~(ANY_BOOST_TRIGGERS | RACING_SPINOUT_TRIGGERS | STATE_TRANSITION_TRIGGERS)) |
+            UNUSED_TRIGGER_0x20000;
     }
     // Near spinout (banana)
     if ((player->effects & BANANA_NEAR_SPINOUT_EFFECT) == BANANA_NEAR_SPINOUT_EFFECT) {
@@ -1443,41 +1456,51 @@ void func_8002B5C0(Player* player, UNUSED s8 playerId, UNUSED s8 screenId) {
     if ((player->kartProps & DRIVING_SPINOUT) != 0) {
         player->triggers &= ALL_TRIGGERS & ~(ANY_BOOST_TRIGGERS | RACING_SPINOUT_TRIGGERS | STATE_TRANSITION_TRIGGERS);
     }
-    //unclear
+    // unclear
     if ((player->effects & UNKNOWN_EFFECT_0x80000) == UNKNOWN_EFFECT_0x80000) {
-        player->triggers &= ALL_TRIGGERS & ~((HIT_TRIGGERS ^ LIGHTNING_STRIKE_TRIGGER) | ANY_BOOST_TRIGGERS | RACING_SPINOUT_TRIGGERS | STATE_TRANSITION_TRIGGERS);
+        player->triggers &= ALL_TRIGGERS & ~((HIT_TRIGGERS ^ LIGHTNING_STRIKE_TRIGGER) | ANY_BOOST_TRIGGERS |
+                                             RACING_SPINOUT_TRIGGERS | STATE_TRANSITION_TRIGGERS);
     }
-    //unclear
+    // unclear
     if ((player->effects & UNKNOWN_EFFECT_0x800000) == UNKNOWN_EFFECT_0x800000) {
-        player->triggers &= ALL_TRIGGERS & ~(HIT_TRIGGERS | ANY_BOOST_TRIGGERS | RACING_SPINOUT_TRIGGERS | STATE_TRANSITION_TRIGGERS);
+        player->triggers &=
+            ALL_TRIGGERS & ~(HIT_TRIGGERS | ANY_BOOST_TRIGGERS | RACING_SPINOUT_TRIGGERS | STATE_TRANSITION_TRIGGERS);
     }
-    //squished
+    // squished
     if ((player->effects & SQUISH_EFFECT) == SQUISH_EFFECT) {
-        player->triggers &= (ALL_TRIGGERS & ~(HIT_TRIGGERS | ANY_BOOST_TRIGGERS | RACING_SPINOUT_TRIGGERS | STATE_TRANSITION_TRIGGERS)) | THWOMP_SQUISH_TRIGGER;
+        player->triggers &= (ALL_TRIGGERS & ~(HIT_TRIGGERS | ANY_BOOST_TRIGGERS | RACING_SPINOUT_TRIGGERS |
+                                              STATE_TRANSITION_TRIGGERS)) |
+                            THWOMP_SQUISH_TRIGGER;
     }
-    //explosion crash
+    // explosion crash
     if ((player->effects & EXPLOSION_CRASH_EFFECT) == EXPLOSION_CRASH_EFFECT) {
-        player->triggers &= ALL_TRIGGERS & ~((HIT_TRIGGERS ^ LIGHTNING_STRIKE_TRIGGER) | ANY_BOOST_TRIGGERS | RACING_SPINOUT_TRIGGERS | STATE_TRANSITION_TRIGGERS);
+        player->triggers &= ALL_TRIGGERS & ~((HIT_TRIGGERS ^ LIGHTNING_STRIKE_TRIGGER) | ANY_BOOST_TRIGGERS |
+                                             RACING_SPINOUT_TRIGGERS | STATE_TRANSITION_TRIGGERS);
     }
     // hit by star or red shell
     if ((player->effects & HIT_BY_STAR_EFFECT) == HIT_BY_STAR_EFFECT) {
-        player->triggers &= ALL_TRIGGERS & ~((HIT_TRIGGERS ^ LIGHTNING_STRIKE_TRIGGER) | ANY_BOOST_TRIGGERS | RACING_SPINOUT_TRIGGERS | STATE_TRANSITION_TRIGGERS);
+        player->triggers &= ALL_TRIGGERS & ~((HIT_TRIGGERS ^ LIGHTNING_STRIKE_TRIGGER) | ANY_BOOST_TRIGGERS |
+                                             RACING_SPINOUT_TRIGGERS | STATE_TRANSITION_TRIGGERS);
     }
     // boost asphalt
     if ((player->effects & BOOST_RAMP_ASPHALT_EFFECT) == BOOST_RAMP_ASPHALT_EFFECT) {
-        player->triggers &= ALL_TRIGGERS & ~(HIT_TRIGGERS | ANY_BOOST_TRIGGERS | RACING_SPINOUT_TRIGGERS | STATE_TRANSITION_TRIGGERS);
+        player->triggers &=
+            ALL_TRIGGERS & ~(HIT_TRIGGERS | ANY_BOOST_TRIGGERS | RACING_SPINOUT_TRIGGERS | STATE_TRANSITION_TRIGGERS);
     }
     // boost ramp
     if ((player->effects & BOOST_RAMP_WOOD_EFFECT) == BOOST_RAMP_WOOD_EFFECT) {
-        player->triggers &= ALL_TRIGGERS & ~(HIT_TRIGGERS | ANY_BOOST_TRIGGERS | RACING_SPINOUT_TRIGGERS | STATE_TRANSITION_TRIGGERS);
+        player->triggers &=
+            ALL_TRIGGERS & ~(HIT_TRIGGERS | ANY_BOOST_TRIGGERS | RACING_SPINOUT_TRIGGERS | STATE_TRANSITION_TRIGGERS);
     }
     // Terrain tumble
     if ((player->effects & TERRAIN_TUMBLE_EFFECT) == TERRAIN_TUMBLE_EFFECT) {
-        player->triggers &= ALL_TRIGGERS & ~(HIT_TRIGGERS | ANY_BOOST_TRIGGERS | RACING_SPINOUT_TRIGGERS | STATE_TRANSITION_TRIGGERS);
+        player->triggers &=
+            ALL_TRIGGERS & ~(HIT_TRIGGERS | ANY_BOOST_TRIGGERS | RACING_SPINOUT_TRIGGERS | STATE_TRANSITION_TRIGGERS);
     }
     // star
     if ((player->effects & STAR_EFFECT) == STAR_EFFECT) {
-        player->triggers &= ALL_TRIGGERS & ~(HIT_TRIGGERS | SHROOM_TRIGGER | RACING_SPINOUT_TRIGGERS | STATE_TRANSITION_TRIGGERS);
+        player->triggers &=
+            ALL_TRIGGERS & ~(HIT_TRIGGERS | SHROOM_TRIGGER | RACING_SPINOUT_TRIGGERS | STATE_TRANSITION_TRIGGERS);
     }
     // boo
     if ((player->effects & BOO_EFFECT) == BOO_EFFECT) {
@@ -1489,7 +1512,8 @@ void func_8002B5C0(Player* player, UNUSED s8 playerId, UNUSED s8 screenId) {
     }
     // CPU_FAST_EFFECTS
     if ((player->effects & LIGHTNING_STRIKE_EFFECT) == LIGHTNING_STRIKE_EFFECT) {
-        player->triggers &= ALL_TRIGGERS & ~(HIT_TRIGGERS | ANY_BOOST_TRIGGERS | RACING_SPINOUT_TRIGGERS | STATE_TRANSITION_TRIGGERS);
+        player->triggers &=
+            ALL_TRIGGERS & ~(HIT_TRIGGERS | ANY_BOOST_TRIGGERS | RACING_SPINOUT_TRIGGERS | STATE_TRANSITION_TRIGGERS);
     }
 }
 
@@ -1500,7 +1524,7 @@ void func_8002B830(Player* player, s8 playerId, s8 screenId) {
     if (player->triggers != 0) {
         apply_triggers(player, playerId, screenId);
     }
-    if ((player->kartProps & UNUSED_0x400) != 0) { //can never be true
+    if ((player->kartProps & UNUSED_0x400) != 0) { // can never be true
         func_800911B4(player, playerId);
     }
 }
@@ -1839,8 +1863,10 @@ void func_8002C4F8(Player* player, s8 playerIndex) {
     } else if ((player->effects & MIDAIR_EFFECT) != MIDAIR_EFFECT) {
         player->lakitu_props &= ~WENT_OVER_OOB;
     }
-    if ((player->type & PLAYER_CPU) && ((func_802ABDF4(player->collision.meshIndexZX) != 0) || (player->lakitu_props & LAKITU_RETRIEVAL))) {
-        if (!(player->lakitu_props & HELD_BY_LAKITU) && !(player->lakitu_props & LAKITU_SCENE) && !(player->effects & LOST_RACE_EFFECT)) {
+    if ((player->type & PLAYER_CPU) &&
+        ((func_802ABDF4(player->collision.meshIndexZX) != 0) || (player->lakitu_props & LAKITU_RETRIEVAL))) {
+        if (!(player->lakitu_props & HELD_BY_LAKITU) && !(player->lakitu_props & LAKITU_SCENE) &&
+            !(player->effects & LOST_RACE_EFFECT)) {
             func_80090778(player);
             func_80090868(player);
         }
@@ -1953,7 +1979,8 @@ void func_8002C954(Player* player, s8 playerId, Vec3f velocity) {
 }
 
 void apply_effect(Player* player, s8 playerIndex, s8 arg2) {
-    if (((player->lakitu_props & HELD_BY_LAKITU) == HELD_BY_LAKITU) || ((player->lakitu_props & LAKITU_SCENE) == LAKITU_SCENE)) {
+    if (((player->lakitu_props & HELD_BY_LAKITU) == HELD_BY_LAKITU) ||
+        ((player->lakitu_props & LAKITU_SCENE) == LAKITU_SCENE)) {
         func_80090970(player, playerIndex, arg2);
     }
     if ((player->effects & BANANA_NEAR_SPINOUT_EFFECT) == BANANA_NEAR_SPINOUT_EFFECT) {
@@ -2217,7 +2244,8 @@ void func_8002D268(Player* player, UNUSED Camera* camera, s8 screenId, s8 player
         (((((f64) ((sp184[1] + gravityY) + sp160[1])) - (newVelocity[1] * (0.12 * ((f64) player->kartFriction)))) /
           6000.0) /
          ((f64) player->unk_DAC));
-    if (((((player->lakitu_props & HELD_BY_LAKITU) == HELD_BY_LAKITU) || ((player->lakitu_props & LAKITU_SCENE) == LAKITU_SCENE)) ||
+    if (((((player->lakitu_props & HELD_BY_LAKITU) == HELD_BY_LAKITU) ||
+          ((player->lakitu_props & LAKITU_SCENE) == LAKITU_SCENE)) ||
          ((player->effects & SQUISH_EFFECT) == SQUISH_EFFECT)) ||
         (player->lakitu_props & LAKITU_RETRIEVAL)) {
         newVelocity[0] = 0.0f;
@@ -2239,7 +2267,8 @@ void func_8002D268(Player* player, UNUSED Camera* camera, s8 screenId, s8 player
     nextY = posY + player->velocity[1];
     nextZ = posZ + player->velocity[2] + D_8018CE10[playerId].unk_04[2];
 
-    if (((((player->lakitu_props & HELD_BY_LAKITU) != HELD_BY_LAKITU) && ((player->lakitu_props & LAKITU_SCENE) != LAKITU_SCENE)) &&
+    if (((((player->lakitu_props & HELD_BY_LAKITU) != HELD_BY_LAKITU) &&
+          ((player->lakitu_props & LAKITU_SCENE) != LAKITU_SCENE)) &&
          ((player->effects & SQUISH_EFFECT) != SQUISH_EFFECT)) &&
         (!(player->lakitu_props & LAKITU_RETRIEVAL))) {
         func_8002AAC0(player);
@@ -2463,7 +2492,8 @@ void func_8002E594(Player* player, UNUSED Camera* camera, s8 screenId, s8 player
         gravityX =
             -1 * (player->unk_064[0]) + (((-player->collision.orientationVector[0]) * player->kartGravity) * 0.1);
         gravityY = (-player->collision.orientationVector[1]) * player->kartGravity;
-        gravityZ = -1 * (player->unk_064[2]) + (((-player->collision.orientationVector[2]) * player->kartGravity) * 0.1);
+        gravityZ =
+            -1 * (player->unk_064[2]) + (((-player->collision.orientationVector[2]) * player->kartGravity) * 0.1);
     } else {
         gravityX = -1 * player->unk_064[0];
         gravityY = -1 * player->kartGravity;
@@ -2492,19 +2522,25 @@ void func_8002E594(Player* player, UNUSED Camera* camera, s8 screenId, s8 player
         ((player->effects & HIT_BY_GREEN_SHELL_EFFECT) != HIT_BY_GREEN_SHELL_EFFECT) &&
         ((player->effects & EXPLOSION_CRASH_EFFECT) != EXPLOSION_CRASH_EFFECT) &&
         ((player->effects & HIT_BY_STAR_EFFECT) != HIT_BY_STAR_EFFECT)) {
-        newVelocity[0] += (((((spEC[0] + gravityX) + spD4[0])) - (newVelocity[0] * (0.12 * player->kartFriction))) / 6000) /
-                   ((player->unk_20C * 5.0f) + 1.0f);
-        newVelocity[2] += (((((spEC[2] + gravityZ) + spD4[2])) - (newVelocity[2] * (0.12 * player->kartFriction))) / 6000) /
-                   ((player->unk_20C * 5.0f) + 1.0f);
+        newVelocity[0] +=
+            (((((spEC[0] + gravityX) + spD4[0])) - (newVelocity[0] * (0.12 * player->kartFriction))) / 6000) /
+            ((player->unk_20C * 5.0f) + 1.0f);
+        newVelocity[2] +=
+            (((((spEC[2] + gravityZ) + spD4[2])) - (newVelocity[2] * (0.12 * player->kartFriction))) / 6000) /
+            ((player->unk_20C * 5.0f) + 1.0f);
     } else {
         newVelocity[0] +=
-            ((((f64) (spEC[0] + gravityX + spD4[0]) - (newVelocity[0] * (0.2 * (f64) player->kartFriction))) / 6000) * 0.08);
+            ((((f64) (spEC[0] + gravityX + spD4[0]) - (newVelocity[0] * (0.2 * (f64) player->kartFriction))) / 6000) *
+             0.08);
         newVelocity[2] +=
-            ((((f64) (spEC[2] + gravityZ + spD4[2]) - (newVelocity[2] * (0.2 * (f64) player->kartFriction))) / 6000) * 0.08);
+            ((((f64) (spEC[2] + gravityZ + spD4[2]) - (newVelocity[2] * (0.2 * (f64) player->kartFriction))) / 6000) *
+             0.08);
     }
-    newVelocity[1] += (((((spEC[1] + gravityY) + spD4[1])) - (newVelocity[1] * (0.12 * player->kartFriction))) / 6000) / player->unk_DAC;
+    newVelocity[1] += (((((spEC[1] + gravityY) + spD4[1])) - (newVelocity[1] * (0.12 * player->kartFriction))) / 6000) /
+                      player->unk_DAC;
 
-    if (((player->lakitu_props & HELD_BY_LAKITU) == HELD_BY_LAKITU) || ((player->lakitu_props & LAKITU_SCENE) == LAKITU_SCENE)) {
+    if (((player->lakitu_props & HELD_BY_LAKITU) == HELD_BY_LAKITU) ||
+        ((player->lakitu_props & LAKITU_SCENE) == LAKITU_SCENE)) {
         newVelocity[0] = 0.0f;
         newVelocity[1] = 0.0f;
         newVelocity[2] = 0.0f;
@@ -2980,7 +3016,8 @@ f32 func_80030150(Player* player, s8 playerIndex) {
                 var_f0 += D_800E2E90[player->characterId][player->tyres[FRONT_LEFT].surfaceType];
             }
         }
-        if (((player->effects & MIDAIR_EFFECT) != MIDAIR_EFFECT) && ((player->lakitu_props & HELD_BY_LAKITU) != HELD_BY_LAKITU)) {
+        if (((player->effects & MIDAIR_EFFECT) != MIDAIR_EFFECT) &&
+            ((player->lakitu_props & HELD_BY_LAKITU) != HELD_BY_LAKITU)) {
             temp_lo = player->slopeAccel / 182;
             if (var_f2 >= 20.0f) {
                 if ((temp_lo > 0x11) || (temp_lo < -0x11)) {
@@ -3071,7 +3108,8 @@ f32 func_80030150(Player* player, s8 playerIndex) {
     if (var_f2 < 0.0f) {
         var_f2 = 0.0f;
     }
-    if (((player->lakitu_props & HELD_BY_LAKITU) == HELD_BY_LAKITU) || ((player->lakitu_props & LAKITU_SCENE) == LAKITU_SCENE) ||
+    if (((player->lakitu_props & HELD_BY_LAKITU) == HELD_BY_LAKITU) ||
+        ((player->lakitu_props & LAKITU_SCENE) == LAKITU_SCENE) ||
         ((player->type & PLAYER_START_SEQUENCE) == PLAYER_START_SEQUENCE)) {
         return (1.0f - player->unk_104) * var_f2;
     }
@@ -3095,7 +3133,8 @@ void func_80030A34(Player* player) {
     f32 var_f0;
     f32 var_f2;
 
-    if (((player->lakitu_props & HELD_BY_LAKITU) != HELD_BY_LAKITU) && ((player->lakitu_props & LAKITU_SCENE) != LAKITU_SCENE)) {
+    if (((player->lakitu_props & HELD_BY_LAKITU) != HELD_BY_LAKITU) &&
+        ((player->lakitu_props & LAKITU_SCENE) != LAKITU_SCENE)) {
         if ((((player->speed / 18.0f) * 216.0f) >= 8.0f) && (player->unk_DB4.unkC < 1.0f)) {
             switch (player->surfaceType) { /* irregular */
                 case ASPHALT:
@@ -3721,7 +3760,8 @@ void player_accelerate_global(Player* player, s32 playerIndex) {
     if ((gPlayerCurrentSpeed[playerIndex] >= 0.0) && (gPlayerCurrentSpeed[playerIndex] < ((f64) player->topSpeed * 0.1))) {
         gPlayerCurrentSpeed[playerIndex] += gKartAccelerationTables[player->characterId][0] * 3.2;
     }
-    if (((player->topSpeed * 0.1) <= gPlayerCurrentSpeed[playerIndex]) && (gPlayerCurrentSpeed[playerIndex] < (player->topSpeed * 0.2))) {
+    if (((player->topSpeed * 0.1) <= gPlayerCurrentSpeed[playerIndex]) &&
+        (gPlayerCurrentSpeed[playerIndex] < (player->topSpeed * 0.2))) {
         gPlayerCurrentSpeed[playerIndex] += gKartAccelerationTables[player->characterId][1] * 3.2;
     }
     if (((player->topSpeed * 0.2) <= gPlayerCurrentSpeed[playerIndex]) &&
@@ -4245,8 +4285,10 @@ void apply_cpu_turn(Player* player, s16 targetAngle) {
                     }
                     player->unk_078 = var_v0 * var_f0;
                 }
-                if ((((player->effects & HOP_EFFECT) != HOP_EFFECT) && (player->unk_0C0 < 0x3D) && (player->unk_0C0 > -0x3D)) ||
-                    (((player->speed / 18.0f) * 216.0f) <= 20.0f) || ((player->effects & ENEMY_BONK_EFFECT) == ENEMY_BONK_EFFECT)) {
+                if ((((player->effects & HOP_EFFECT) != HOP_EFFECT) && (player->unk_0C0 < 0x3D) &&
+                     (player->unk_0C0 > -0x3D)) ||
+                    (((player->speed / 18.0f) * 216.0f) <= 20.0f) ||
+                    ((player->effects & ENEMY_BONK_EFFECT) == ENEMY_BONK_EFFECT)) {
                     func_80036CB4(player);
                 }
             }
@@ -4662,7 +4704,8 @@ void handle_a_press_for_player_during_race(Player* player, struct Controller* co
         ((player->type & PLAYER_CPU) != PLAYER_CPU)) {
         // If not start sequence
         if ((player->type & PLAYER_START_SEQUENCE) != PLAYER_START_SEQUENCE) {
-            if (((player->lakitu_props & HELD_BY_LAKITU) == HELD_BY_LAKITU) || ((player->lakitu_props & LAKITU_SCENE) == LAKITU_SCENE)) {
+            if (((player->lakitu_props & HELD_BY_LAKITU) == HELD_BY_LAKITU) ||
+                ((player->lakitu_props & LAKITU_SCENE) == LAKITU_SCENE)) {
                 if (controller->button & A_BUTTON) {
                     player_accelerate(player);
                 } else {
@@ -4704,11 +4747,13 @@ void handle_a_press_for_all_players_during_race(void) {
                     if (D_8015F890 != 1) {
                         handle_a_press_for_player_during_race(gPlayerOne, gControllerOne, 0);
                         temp_v0_3 = gPlayerTwo->type;
-                        if (((temp_v0_3 & PLAYER_INVISIBLE_OR_BOMB) == PLAYER_INVISIBLE_OR_BOMB) && ((temp_v0_3 & PLAYER_CINEMATIC_MODE) != PLAYER_CINEMATIC_MODE)) {
+                        if (((temp_v0_3 & PLAYER_INVISIBLE_OR_BOMB) == PLAYER_INVISIBLE_OR_BOMB) &&
+                            ((temp_v0_3 & PLAYER_CINEMATIC_MODE) != PLAYER_CINEMATIC_MODE)) {
                             handle_a_press_for_player_during_race(gPlayerTwo, gControllerSix, 1);
                         }
                         temp_v0_4 = gPlayerThree->type;
-                        if (((temp_v0_4 & PLAYER_INVISIBLE_OR_BOMB) == PLAYER_INVISIBLE_OR_BOMB) && ((temp_v0_4 & PLAYER_CINEMATIC_MODE) != PLAYER_CINEMATIC_MODE)) {
+                        if (((temp_v0_4 & PLAYER_INVISIBLE_OR_BOMB) == PLAYER_INVISIBLE_OR_BOMB) &&
+                            ((temp_v0_4 & PLAYER_CINEMATIC_MODE) != PLAYER_CINEMATIC_MODE)) {
                             handle_a_press_for_player_during_race(gPlayerThree, gControllerSeven, 2);
                             return;
                         }
@@ -4717,11 +4762,13 @@ void handle_a_press_for_all_players_during_race(void) {
                             handle_a_press_for_player_during_race(gPlayerOne, gControllerEight, 0);
                         }
                         temp_v0_5 = gPlayerTwo->type;
-                        if (((temp_v0_5 & PLAYER_INVISIBLE_OR_BOMB) == PLAYER_INVISIBLE_OR_BOMB) && ((temp_v0_5 & PLAYER_CINEMATIC_MODE) != PLAYER_CINEMATIC_MODE)) {
+                        if (((temp_v0_5 & PLAYER_INVISIBLE_OR_BOMB) == PLAYER_INVISIBLE_OR_BOMB) &&
+                            ((temp_v0_5 & PLAYER_CINEMATIC_MODE) != PLAYER_CINEMATIC_MODE)) {
                             handle_a_press_for_player_during_race(gPlayerTwo, gControllerSix, 1);
                         }
                         temp_v0_6 = gPlayerThree->type;
-                        if (((temp_v0_6 & PLAYER_INVISIBLE_OR_BOMB) == PLAYER_INVISIBLE_OR_BOMB) && ((temp_v0_6 & PLAYER_CINEMATIC_MODE) != PLAYER_CINEMATIC_MODE)) {
+                        if (((temp_v0_6 & PLAYER_INVISIBLE_OR_BOMB) == PLAYER_INVISIBLE_OR_BOMB) &&
+                            ((temp_v0_6 & PLAYER_CINEMATIC_MODE) != PLAYER_CINEMATIC_MODE)) {
                             handle_a_press_for_player_during_race(gPlayerThree, gControllerSeven, 2);
                             return;
                         }

--- a/src/player_controller.c
+++ b/src/player_controller.c
@@ -2270,7 +2270,7 @@ void func_8002D268(Player* player, UNUSED Camera* camera, s8 screenId, s8 player
             }
             player->unk_DB4.unkC = 3.0f;
             player->unk_DB4.unk18 = 0;
-            player->unk_0B6 |= 0x100;
+            player->unk_0B6 |= UNK_0B6_POOMP;
             if ((((player->type & PLAYER_HUMAN) == PLAYER_HUMAN) &&
                  ((player->effects & BOOST_RAMP_ASPHALT_EFFECT) == BOOST_RAMP_ASPHALT_EFFECT)) &&
                 ((player->type & PLAYER_INVISIBLE_OR_BOMB) != PLAYER_INVISIBLE_OR_BOMB)) {
@@ -2541,7 +2541,7 @@ void func_8002E594(Player* player, UNUSED Camera* camera, s8 screenId, s8 player
                     player->unk_0C2 = 0x0032;
                 }
                 player->unk_DB4.unk18 = 0;
-                player->unk_0B6 |= 0x100;
+                player->unk_0B6 |= UNK_0B6_POOMP;
                 player->unk_DB4.unkC = 3.0f;
                 if (((player->type & PLAYER_HUMAN) == PLAYER_HUMAN) &&
                     ((player->type & PLAYER_INVISIBLE_OR_BOMB) != PLAYER_INVISIBLE_OR_BOMB)) {
@@ -4258,7 +4258,7 @@ void func_80036C5C(Player* player) {
     if (((player->speed / 18.0f) * 216.0f) > 20.0f) {
         player->unk_204 = 0;
         player->effects |= DRIFTING_EFFECT;
-        player->unk_0B6 |= 0x800;
+        player->unk_0B6 |= UNK_0B6_BOING;
     }
 }
 

--- a/src/player_controller.c
+++ b/src/player_controller.c
@@ -532,7 +532,7 @@ void func_80028864(Player* player, Camera* camera, s8 playerId, s8 screenId) {
                 break;
         }
         if ((isVisible == 1) || ((player->type & PLAYER_INVISIBLE_OR_BOMB) == PLAYER_INVISIBLE_OR_BOMB) ||
-            (gModeSelection == BATTLE) || ((player->unk_0CA & 2) != 0) || (player->unk_0CA & 8) ||
+            (gModeSelection == BATTLE) || ((player->unk_0CA & UNK_0CA_HELD_BY_LAKITU) != 0) || (player->unk_0CA & UNK_0CA_LAKITU_SCENE) ||
             //! @todo make a proper match
             ((*(D_801633F8 + (playerId))) == ((s16) 1U))) {
             player->effects &= ~LOST_RACE_EFFECT;
@@ -589,11 +589,10 @@ void func_80028C44(Player* player, Camera* camera, s8 playerId, s8 screenId) {
 
 void func_80028D3C(Player* player, Camera* camera, s8 playerId, s8 screenId) {
     if ((((player->type & PLAYER_START_SEQUENCE) == 0) && (D_800DC510 != 5)) || (player->unk_0CA & 2) != 0 ||
-        (player->unk_0CA & 8) != 0 ||
+        (player->unk_0CA & UNK_0CA_LAKITU_SCENE) != 0 ||
         (player->effects & (LIGHTNING_EFFECT | EXPLOSION_CRASH_EFFECT | HIT_BY_STAR_EFFECT | SQUISH_EFFECT |
                             POST_SQUISH_EFFECT | TERRAIN_TUMBLE_EFFECT | 0xC00 | 0xC0)) != 0) {
         player->effects &= ~LOST_RACE_EFFECT;
-
         if (((player->effects & BANANA_SPINOUT_EFFECT) == BANANA_SPINOUT_EFFECT) ||
             ((player->effects & DRIVING_SPINOUT_EFFECT) == DRIVING_SPINOUT_EFFECT) ||
             ((player->effects & HIT_BY_GREEN_SHELL_EFFECT) == HIT_BY_GREEN_SHELL_EFFECT) ||
@@ -791,7 +790,7 @@ void func_8002934C(Player* player, Camera* camera, s8 screenId, s8 playerId) {
         ((player->effects & UNKNOWN_EFFECT_0x800000) == UNKNOWN_EFFECT_0x800000) || (player->unk_044 & UNK_044_UNUSED_0x800)) {
         player->unk_050[screenId] = 0;
     }
-    if (((player->effects & MIDAIR_EFFECT) == MIDAIR_EFFECT) && ((player->unk_0CA & 2) == 2)) {
+    if (((player->effects & MIDAIR_EFFECT) == MIDAIR_EFFECT) && ((player->unk_0CA & UNK_0CA_HELD_BY_LAKITU) == UNK_0CA_HELD_BY_LAKITU)) {
         player->unk_050[screenId] = 0;
     }
     var_a0 = (player->unk_048[screenId] + player->rotation[1] + player->unk_0C0);
@@ -947,7 +946,7 @@ void func_80029B4C(Player* player, UNUSED f32 arg1, f32 arg2, UNUSED f32 arg3) {
     temp_f2_3 = ((gCharacterSize[player->characterId] * 18.0f) + 1.0f) * player->size;
     temp_f0_2 = player->unk_23C - player->unk_230;
     player->unk_206 = -atan1s(temp_f0_2 / temp_f2_3);
-    if (((player->unk_0CA & 2) == 2) || (player->effects & MIDAIR_EFFECT)) {
+    if (((player->unk_0CA & UNK_0CA_HELD_BY_LAKITU) == UNK_0CA_HELD_BY_LAKITU) || (player->effects & MIDAIR_EFFECT)) {
         player->unk_206 = 0;
     }
     if ((player->effects & MIDAIR_EFFECT) != MIDAIR_EFFECT) {
@@ -963,7 +962,7 @@ void func_80029B4C(Player* player, UNUSED f32 arg1, f32 arg2, UNUSED f32 arg3) {
         }
         move_s16_towards(&player->slopeAccel, temp_v0, 0.5f);
     }
-    if (((player->effects & MIDAIR_EFFECT) == MIDAIR_EFFECT) && ((player->unk_0CA & 2) == 2)) {
+    if (((player->effects & MIDAIR_EFFECT) == MIDAIR_EFFECT) && ((player->unk_0CA & UNK_0CA_HELD_BY_LAKITU) == UNK_0CA_HELD_BY_LAKITU)) {
         player->slopeAccel = (s16) ((s32) player->unk_D9C);
     }
     player->surfaceType = get_surface_type(player->collision.meshIndexZX) & 0xFF;
@@ -1425,7 +1424,7 @@ void apply_triggers(Player* player, s8 playerId, UNUSED s8 screenId) {
 }
 
 void func_8002B5C0(Player* player, UNUSED s8 playerId, UNUSED s8 screenId) {
-    if (((player->unk_0CA & 8) != 0) || ((player->unk_0CA & 2) != 0)) {
+    if (((player->unk_0CA & UNK_0CA_LAKITU_SCENE) != 0) || ((player->unk_0CA & UNK_0CA_HELD_BY_LAKITU) != 0)) {
         player->triggers &= ALL_TRIGGERS & ~(HIT_TRIGGERS | ANY_BOOST_TRIGGERS | RACING_SPINOUT_TRIGGERS | STATE_TRANSITION_TRIGGERS);
     }
     // Green shell
@@ -1789,7 +1788,7 @@ void func_8002C17C(Player* player, s8 playerId) {
             } else if (D_80165330[playerId] == 0) {
                 gCopyNearestPathPointByPlayerId[playerId] = gNearestPathPointByPlayerId[playerId];
                 gCopyPathIndexByPlayerId[playerId] = gPathIndexByPlayerId[playerId];
-            } else if (!((player->effects & MIDAIR_EFFECT) || (player->unk_0CA & 1))) {
+            } else if (!((player->effects & MIDAIR_EFFECT) || (player->unk_0CA & UNK_0CA_LAKITU_RETRIEVAL))) {
                 D_80165330[playerId] = 0;
             }
             break;
@@ -1833,15 +1832,15 @@ void func_8002C4F8(Player* player, s8 playerIndex) {
     }
     if ((player->boundingBoxSize < (D_801652A0[playerIndex] - player->pos[1])) &&
         (player->collision.surfaceDistance[2] >= 600.0f)) {
-        player->unk_0CA |= 1;
+        player->unk_0CA |= UNK_0CA_LAKITU_RETRIEVAL;
     }
     if (player->collision.surfaceDistance[2] >= 600.0f) {
-        player->unk_0CA |= 0x0100;
+        player->unk_0CA |= UNK_0CA_WENT_OVER_OOB;
     } else if ((player->effects & MIDAIR_EFFECT) != MIDAIR_EFFECT) {
-        player->unk_0CA &= ~0x0100;
+        player->unk_0CA &= ~UNK_0CA_WENT_OVER_OOB;
     }
-    if ((player->type & PLAYER_CPU) && ((func_802ABDF4(player->collision.meshIndexZX) != 0) || (player->unk_0CA & 1))) {
-        if (!(player->unk_0CA & 2) && !(player->unk_0CA & 8) && !(player->effects & LOST_RACE_EFFECT)) {
+    if ((player->type & PLAYER_CPU) && ((func_802ABDF4(player->collision.meshIndexZX) != 0) || (player->unk_0CA & UNK_0CA_LAKITU_RETRIEVAL))) {
+        if (!(player->unk_0CA & UNK_0CA_HELD_BY_LAKITU) && !(player->unk_0CA & UNK_0CA_LAKITU_SCENE) && !(player->effects & LOST_RACE_EFFECT)) {
             func_80090778(player);
             func_80090868(player);
         }
@@ -1906,7 +1905,7 @@ void func_8002C954(Player* player, s8 playerId, Vec3f velocity) {
          ((((temp_f0 >= 20.0f) || (temp_f0 < (-1.0f))) && ((player->effects & TERRAIN_TUMBLE_EFFECT) == 0)) &&
           (player->effects & MIDAIR_EFFECT)) ||
          ((player->collision.unk34 == 0) && ((player->effects & TERRAIN_TUMBLE_EFFECT) == 0))) &&
-        (((player->unk_0CA & 2) == 0) || (!(player->unk_0CA & 8)))) {
+        (((player->unk_0CA & UNK_0CA_HELD_BY_LAKITU) == 0) || (!(player->unk_0CA & UNK_0CA_LAKITU_SCENE)))) {
         func_8008F494(player, playerId);
     }
     if ((player->unk_046 & 0x20) != 0x20) {
@@ -1954,7 +1953,7 @@ void func_8002C954(Player* player, s8 playerId, Vec3f velocity) {
 }
 
 void apply_effect(Player* player, s8 playerIndex, s8 arg2) {
-    if (((player->unk_0CA & 2) == 2) || ((player->unk_0CA & 8) == 8)) {
+    if (((player->unk_0CA & UNK_0CA_HELD_BY_LAKITU) == UNK_0CA_HELD_BY_LAKITU) || ((player->unk_0CA & UNK_0CA_LAKITU_SCENE) == UNK_0CA_LAKITU_SCENE)) {
         func_80090970(player, playerIndex, arg2);
     }
     if ((player->effects & BANANA_NEAR_SPINOUT_EFFECT) == BANANA_NEAR_SPINOUT_EFFECT) {
@@ -2218,9 +2217,9 @@ void func_8002D268(Player* player, UNUSED Camera* camera, s8 screenId, s8 player
         (((((f64) ((sp184[1] + gravityY) + sp160[1])) - (newVelocity[1] * (0.12 * ((f64) player->kartFriction)))) /
           6000.0) /
          ((f64) player->unk_DAC));
-    if (((((player->unk_0CA & 2) == 2) || ((player->unk_0CA & 8) == 8)) ||
+    if (((((player->unk_0CA & UNK_0CA_HELD_BY_LAKITU) == UNK_0CA_HELD_BY_LAKITU) || ((player->unk_0CA & UNK_0CA_LAKITU_SCENE) == UNK_0CA_LAKITU_SCENE)) ||
          ((player->effects & SQUISH_EFFECT) == SQUISH_EFFECT)) ||
-        (player->unk_0CA & 1)) {
+        (player->unk_0CA & UNK_0CA_LAKITU_RETRIEVAL)) {
         newVelocity[0] = 0.0f;
         newVelocity[1] = 0.0f;
         newVelocity[2] = 0.0f;
@@ -2240,9 +2239,9 @@ void func_8002D268(Player* player, UNUSED Camera* camera, s8 screenId, s8 player
     nextY = posY + player->velocity[1];
     nextZ = posZ + player->velocity[2] + D_8018CE10[playerId].unk_04[2];
 
-    if (((((player->unk_0CA & 2) != 2) && ((player->unk_0CA & 8) != 8)) &&
+    if (((((player->unk_0CA & UNK_0CA_HELD_BY_LAKITU) != UNK_0CA_HELD_BY_LAKITU) && ((player->unk_0CA & UNK_0CA_LAKITU_SCENE) != UNK_0CA_LAKITU_SCENE)) &&
          ((player->effects & SQUISH_EFFECT) != SQUISH_EFFECT)) &&
-        (!(player->unk_0CA & 1))) {
+        (!(player->unk_0CA & UNK_0CA_LAKITU_RETRIEVAL))) {
         func_8002AAC0(player);
         nextY += player->kartHopVelocity;
         nextY -= 0.02;
@@ -2340,7 +2339,7 @@ void func_8002D268(Player* player, UNUSED Camera* camera, s8 screenId, s8 player
     }
     if (((!(player->effects & MIDAIR_EFFECT)) && (func_802ABDB8(player->collision.meshIndexZX) != 0)) &&
         ((player->effects & TERRAIN_TUMBLE_EFFECT) != TERRAIN_TUMBLE_EFFECT)) {
-        if ((!(player->unk_0CA & 2)) || (!(player->unk_0CA & 8))) {
+        if ((!(player->unk_0CA & UNK_0CA_HELD_BY_LAKITU)) || (!(player->unk_0CA & UNK_0CA_LAKITU_SCENE))) {
             func_8008F494(player, playerId);
         }
     } else if (((!(player->effects & MIDAIR_EFFECT)) && (func_802ABDB8(player->collision.meshIndexZX) == 0)) &&
@@ -2505,7 +2504,7 @@ void func_8002E594(Player* player, UNUSED Camera* camera, s8 screenId, s8 player
     }
     newVelocity[1] += (((((spEC[1] + gravityY) + spD4[1])) - (newVelocity[1] * (0.12 * player->kartFriction))) / 6000) / player->unk_DAC;
 
-    if (((player->unk_0CA & 2) == 2) || ((player->unk_0CA & 8) == 8)) {
+    if (((player->unk_0CA & UNK_0CA_HELD_BY_LAKITU) == UNK_0CA_HELD_BY_LAKITU) || ((player->unk_0CA & UNK_0CA_LAKITU_SCENE) == UNK_0CA_LAKITU_SCENE)) {
         newVelocity[0] = 0.0f;
         newVelocity[1] = 0.0f;
         newVelocity[2] = 0.0f;
@@ -2627,7 +2626,7 @@ void func_8002E594(Player* player, UNUSED Camera* camera, s8 screenId, s8 player
     if (((func_802ABDB8(player->collision.meshIndexZX) != 0) &&
          ((player->effects & TERRAIN_TUMBLE_EFFECT) != TERRAIN_TUMBLE_EFFECT)) &&
         (((player->speed / 18.0f) * 216.0f) >= 20.0f)) {
-        if ((!(player->unk_0CA & 2)) || (!(player->unk_0CA & 8))) {
+        if ((!(player->unk_0CA & UNK_0CA_HELD_BY_LAKITU)) || (!(player->unk_0CA & UNK_0CA_LAKITU_SCENE))) {
             func_8008F494(player, playerId);
         }
     } else if (((!(player->effects & MIDAIR_EFFECT)) && (func_802ABDB8(player->collision.meshIndexZX) == 0)) &&
@@ -2981,7 +2980,7 @@ f32 func_80030150(Player* player, s8 playerIndex) {
                 var_f0 += D_800E2E90[player->characterId][player->tyres[FRONT_LEFT].surfaceType];
             }
         }
-        if (((player->effects & MIDAIR_EFFECT) != MIDAIR_EFFECT) && ((player->unk_0CA & 2) != 2)) {
+        if (((player->effects & MIDAIR_EFFECT) != MIDAIR_EFFECT) && ((player->unk_0CA & UNK_0CA_HELD_BY_LAKITU) != UNK_0CA_HELD_BY_LAKITU)) {
             temp_lo = player->slopeAccel / 182;
             if (var_f2 >= 20.0f) {
                 if ((temp_lo > 0x11) || (temp_lo < -0x11)) {
@@ -3072,7 +3071,7 @@ f32 func_80030150(Player* player, s8 playerIndex) {
     if (var_f2 < 0.0f) {
         var_f2 = 0.0f;
     }
-    if (((player->unk_0CA & 2) == 2) || ((player->unk_0CA & 8) == 8) ||
+    if (((player->unk_0CA & UNK_0CA_HELD_BY_LAKITU) == UNK_0CA_HELD_BY_LAKITU) || ((player->unk_0CA & UNK_0CA_LAKITU_SCENE) == UNK_0CA_LAKITU_SCENE) ||
         ((player->type & PLAYER_START_SEQUENCE) == PLAYER_START_SEQUENCE)) {
         return (1.0f - player->unk_104) * var_f2;
     }
@@ -3096,7 +3095,7 @@ void func_80030A34(Player* player) {
     f32 var_f0;
     f32 var_f2;
 
-    if (((player->unk_0CA & 2) != 2) && ((player->unk_0CA & 8) != 8)) {
+    if (((player->unk_0CA & UNK_0CA_HELD_BY_LAKITU) != UNK_0CA_HELD_BY_LAKITU) && ((player->unk_0CA & UNK_0CA_LAKITU_SCENE) != UNK_0CA_LAKITU_SCENE)) {
         if ((((player->speed / 18.0f) * 216.0f) >= 8.0f) && (player->unk_DB4.unkC < 1.0f)) {
             switch (player->surfaceType) { /* irregular */
                 case ASPHALT:
@@ -4663,7 +4662,7 @@ void handle_a_press_for_player_during_race(Player* player, struct Controller* co
         ((player->type & PLAYER_CPU) != PLAYER_CPU)) {
         // If not start sequence
         if ((player->type & PLAYER_START_SEQUENCE) != PLAYER_START_SEQUENCE) {
-            if (((player->unk_0CA & 2) == 2) || ((player->unk_0CA & 8) == 8)) {
+            if (((player->unk_0CA & UNK_0CA_HELD_BY_LAKITU) == UNK_0CA_HELD_BY_LAKITU) || ((player->unk_0CA & UNK_0CA_LAKITU_SCENE) == UNK_0CA_LAKITU_SCENE)) {
                 if (controller->button & A_BUTTON) {
                     player_accelerate(player);
                 } else {

--- a/src/player_controller.c
+++ b/src/player_controller.c
@@ -1802,20 +1802,20 @@ void func_8002C17C(Player* player, s8 playerId) {
 void func_8002C4F8(Player* player, s8 playerIndex) {
     D_801652A0[playerIndex] = func_802AAB4C(player);
     if (player->pos[1] <= D_801652A0[playerIndex]) {
-        player->unk_0DE |= UNK_0DE_PASS_OOB_OR_FLUID_LEVEL;
+        player->oobProps |= PASS_OOB_OR_FLUID_LEVEL;
     } else {
-        player->unk_0DE &= ~UNK_0DE_PASS_OOB_OR_FLUID_LEVEL;
+        player->oobProps &= ~PASS_OOB_OR_FLUID_LEVEL;
     }
     if (player->boundingBoxSize < (D_801652A0[playerIndex] - player->pos[1])) {
-        player->unk_0DE |= UNK_0DE_UNDER_OOB_OR_FLUID_LEVEL;
-        player->unk_0DE &= ~UNK_0DE_PASS_OOB_OR_FLUID_LEVEL;
+        player->oobProps |= UNDER_OOB_OR_FLUID_LEVEL;
+        player->oobProps &= ~PASS_OOB_OR_FLUID_LEVEL;
     } else {
-        player->unk_0DE &= ~UNK_0DE_UNDER_OOB_OR_FLUID_LEVEL;
+        player->oobProps &= ~UNDER_OOB_OR_FLUID_LEVEL;
     }
     if (player->boundingBoxSize < (D_801652A0[playerIndex] - player->pos[1])) {
-        if ((player->unk_0DE & UNK_0DE_UNDER_FLUID_LEVEL) != UNK_0DE_UNDER_FLUID_LEVEL) {
-            player->unk_0DE |= UNK_0DE_UNDER_OOB_LEVEL;
-            player->unk_0DE |= UNK_0DE_UNDER_FLUID_LEVEL;
+        if ((player->oobProps & UNDER_FLUID_LEVEL) != UNDER_FLUID_LEVEL) {
+            player->oobProps |= UNDER_OOB_LEVEL;
+            player->oobProps |= UNDER_FLUID_LEVEL;
             if ((gCurrentCourseId != COURSE_KOOPA_BEACH) && (gCurrentCourseId != COURSE_SKYSCRAPER) &&
                 (gCurrentCourseId != COURSE_RAINBOW_ROAD) && ((player->type & PLAYER_HUMAN) == PLAYER_HUMAN)) {
                 if ((gCurrentCourseId == COURSE_BOWSER_CASTLE) || (gCurrentCourseId == COURSE_BIG_DONUT)) {
@@ -1828,7 +1828,7 @@ void func_8002C4F8(Player* player, s8 playerIndex) {
     }
     if ((gCurrentCourseId == COURSE_KOOPA_BEACH) || (gCurrentCourseId == COURSE_SKYSCRAPER) ||
         (gCurrentCourseId == COURSE_RAINBOW_ROAD)) {
-        player->unk_0DE &= ~(UNK_0DE_UNDER_OOB_LEVEL | UNK_0DE_UNDER_FLUID_LEVEL);
+        player->oobProps &= ~(UNDER_OOB_LEVEL | UNDER_FLUID_LEVEL);
     }
     if ((player->boundingBoxSize < (D_801652A0[playerIndex] - player->pos[1])) &&
         (player->collision.surfaceDistance[2] >= 600.0f)) {
@@ -3020,10 +3020,10 @@ f32 func_80030150(Player* player, s8 playerIndex) {
                 var_f0 += -0.25;
             }
         }
-        if ((player->unk_0DE & UNK_0DE_UNDER_OOB_OR_FLUID_LEVEL) == UNK_0DE_UNDER_OOB_OR_FLUID_LEVEL) {
+        if ((player->oobProps & UNDER_OOB_OR_FLUID_LEVEL) == UNDER_OOB_OR_FLUID_LEVEL) {
             var_f0 += 0.3;
         } else {
-            if ((player->unk_0DE & UNK_0DE_PASS_OOB_OR_FLUID_LEVEL) == UNK_0DE_PASS_OOB_OR_FLUID_LEVEL) {
+            if ((player->oobProps & PASS_OOB_OR_FLUID_LEVEL) == PASS_OOB_OR_FLUID_LEVEL) {
                 var_f0 += 0.15;
             }
             if (((D_801652A0[playerIndex] - player->tyres[BACK_LEFT].baseHeight) >= 3.5) ||
@@ -3962,11 +3962,11 @@ void func_80033AE0(Player* player, struct Controller* controller, s8 arg2) {
             sp2CC = 8;
         }
     }
-    if ((player->unk_0DE & UNK_0DE_UNDER_OOB_OR_FLUID_LEVEL) == UNK_0DE_UNDER_OOB_OR_FLUID_LEVEL) {
+    if ((player->oobProps & UNDER_OOB_OR_FLUID_LEVEL) == UNDER_OOB_OR_FLUID_LEVEL) {
         sp2C8 *= 1.5;
         sp2CC *= 1.5;
     } else {
-        if ((player->unk_0DE & UNK_0DE_PASS_OOB_OR_FLUID_LEVEL) == UNK_0DE_PASS_OOB_OR_FLUID_LEVEL) {
+        if ((player->oobProps & PASS_OOB_OR_FLUID_LEVEL) == PASS_OOB_OR_FLUID_LEVEL) {
             sp2C8 *= 1.2;
             sp2CC *= 1.2;
         }

--- a/src/player_controller.c
+++ b/src/player_controller.c
@@ -217,22 +217,22 @@ s32 get_player_index_for_player(Player* player) {
 
 void func_80027DA8(Player* player, s8 playerId) {
     if (D_8015F890 != 1) {
-        if ((player->type & 0x10) != 0x10) {
-            if (((D_8018D168 == 1) && ((player->type & PLAYER_HUMAN) == 0x4000)) && ((player->type & 0x100) != 0x100)) {
+        if ((player->type & PLAYER_UNKNOWN_0x10) != PLAYER_UNKNOWN_0x10) {
+            if (((D_8018D168 == 1) && ((player->type & PLAYER_HUMAN) == PLAYER_HUMAN)) && ((player->type & PLAYER_INVISIBLE_OR_BOMB) != PLAYER_INVISIBLE_OR_BOMB)) {
                 func_800C94A4(playerId);
-                player->type |= 0x10;
-            } else if ((player->type & 0x2000) == 0) {
+                player->type |= PLAYER_UNKNOWN_0x10;
+            } else if ((player->type & PLAYER_START_SEQUENCE) == 0) {
                 func_800C9A88(playerId);
-                player->type |= 0x10;
+                player->type |= PLAYER_UNKNOWN_0x10;
             }
         }
-    } else if ((player->type & 0x10) != 0x10) {
+    } else if ((player->type & PLAYER_UNKNOWN_0x10) != PLAYER_UNKNOWN_0x10) {
         if ((D_8018D168 == 1) && (player == gPlayerOne)) {
             func_800C94A4(playerId);
-            player->type |= 0x10;
-        } else if ((player->type & 0x2000) == 0) {
+            player->type |= PLAYER_UNKNOWN_0x10;
+        } else if ((player->type & PLAYER_START_SEQUENCE) == 0) {
             func_800C9A88(playerId);
-            player->type |= 0x10;
+            player->type |= PLAYER_UNKNOWN_0x10;
         }
     }
 }
@@ -555,7 +555,7 @@ void func_80028864(Player* player, Camera* camera, s8 playerId, s8 screenId) {
     } else if ((player->type & PLAYER_STAGING) == PLAYER_STAGING) {
         func_8002D028(player, playerId);
         func_8002F730(player, camera, screenId, playerId);
-    } else if (player->type & 0x80) {
+    } else if (player->type & PLAYER_UNKNOWN_0x80) {
         func_8002D268(player, camera, screenId, playerId);
     } else {
         if ((player->type & PLAYER_HUMAN) != PLAYER_HUMAN) {
@@ -2060,7 +2060,7 @@ void func_8002D028(Player* player, s8 playerIndex) {
     if (temp_f18 <= 8.0f) {
         adjust_angle(&player->rotation[1], -0x8000, 0x016C);
         if ((player->rotation[1] < (-0x7F41)) || (player->rotation[1] > 0x7F41)) {
-            player->type &= ~0x0200;
+            player->type &= ~PLAYER_STAGING;
         }
         player->unk_08C = 0;
         player->speed = 0;
@@ -4704,24 +4704,24 @@ void handle_a_press_for_all_players_during_race(void) {
                     if (D_8015F890 != 1) {
                         handle_a_press_for_player_during_race(gPlayerOne, gControllerOne, 0);
                         temp_v0_3 = gPlayerTwo->type;
-                        if (((temp_v0_3 & 0x100) == 0x100) && ((temp_v0_3 & 0x800) != 0x800)) {
+                        if (((temp_v0_3 & PLAYER_INVISIBLE_OR_BOMB) == PLAYER_INVISIBLE_OR_BOMB) && ((temp_v0_3 & PLAYER_CINEMATIC_MODE) != PLAYER_CINEMATIC_MODE)) {
                             handle_a_press_for_player_during_race(gPlayerTwo, gControllerSix, 1);
                         }
                         temp_v0_4 = gPlayerThree->type;
-                        if (((temp_v0_4 & 0x100) == 0x100) && ((temp_v0_4 & 0x800) != 0x800)) {
+                        if (((temp_v0_4 & PLAYER_INVISIBLE_OR_BOMB) == PLAYER_INVISIBLE_OR_BOMB) && ((temp_v0_4 & PLAYER_CINEMATIC_MODE) != PLAYER_CINEMATIC_MODE)) {
                             handle_a_press_for_player_during_race(gPlayerThree, gControllerSeven, 2);
                             return;
                         }
                     } else {
-                        if ((gPlayerOne->type & 0x800) != 0x800) {
+                        if ((gPlayerOne->type & PLAYER_CINEMATIC_MODE) != PLAYER_CINEMATIC_MODE) {
                             handle_a_press_for_player_during_race(gPlayerOne, gControllerEight, 0);
                         }
                         temp_v0_5 = gPlayerTwo->type;
-                        if (((temp_v0_5 & 0x100) == 0x100) && ((temp_v0_5 & 0x800) != 0x800)) {
+                        if (((temp_v0_5 & PLAYER_INVISIBLE_OR_BOMB) == PLAYER_INVISIBLE_OR_BOMB) && ((temp_v0_5 & PLAYER_CINEMATIC_MODE) != PLAYER_CINEMATIC_MODE)) {
                             handle_a_press_for_player_during_race(gPlayerTwo, gControllerSix, 1);
                         }
                         temp_v0_6 = gPlayerThree->type;
-                        if (((temp_v0_6 & 0x100) == 0x100) && ((temp_v0_6 & 0x800) != 0x800)) {
+                        if (((temp_v0_6 & PLAYER_INVISIBLE_OR_BOMB) == PLAYER_INVISIBLE_OR_BOMB) && ((temp_v0_6 & PLAYER_CINEMATIC_MODE) != PLAYER_CINEMATIC_MODE)) {
                             handle_a_press_for_player_during_race(gPlayerThree, gControllerSeven, 2);
                             return;
                         }

--- a/src/player_controller.c
+++ b/src/player_controller.c
@@ -532,7 +532,7 @@ void func_80028864(Player* player, Camera* camera, s8 playerId, s8 screenId) {
                 break;
         }
         if ((isVisible == 1) || ((player->type & PLAYER_INVISIBLE_OR_BOMB) == PLAYER_INVISIBLE_OR_BOMB) ||
-            (gModeSelection == BATTLE) || ((player->unk_0CA & UNK_0CA_HELD_BY_LAKITU) != 0) || (player->unk_0CA & UNK_0CA_LAKITU_SCENE) ||
+            (gModeSelection == BATTLE) || ((player->lakitu_props & HELD_BY_LAKITU) != 0) || (player->lakitu_props & LAKITU_SCENE) ||
             //! @todo make a proper match
             ((*(D_801633F8 + (playerId))) == ((s16) 1U))) {
             player->effects &= ~LOST_RACE_EFFECT;
@@ -588,8 +588,8 @@ void func_80028C44(Player* player, Camera* camera, s8 playerId, s8 screenId) {
 }
 
 void func_80028D3C(Player* player, Camera* camera, s8 playerId, s8 screenId) {
-    if ((((player->type & PLAYER_START_SEQUENCE) == 0) && (D_800DC510 != 5)) || (player->unk_0CA & 2) != 0 ||
-        (player->unk_0CA & UNK_0CA_LAKITU_SCENE) != 0 ||
+    if ((((player->type & PLAYER_START_SEQUENCE) == 0) && (D_800DC510 != 5)) || (player->lakitu_props & 2) != 0 ||
+        (player->lakitu_props & LAKITU_SCENE) != 0 ||
         (player->effects & (LIGHTNING_EFFECT | EXPLOSION_CRASH_EFFECT | HIT_BY_STAR_EFFECT | SQUISH_EFFECT |
                             POST_SQUISH_EFFECT | TERRAIN_TUMBLE_EFFECT | 0xC00 | 0xC0)) != 0) {
         player->effects &= ~LOST_RACE_EFFECT;
@@ -790,7 +790,7 @@ void func_8002934C(Player* player, Camera* camera, s8 screenId, s8 playerId) {
         ((player->effects & UNKNOWN_EFFECT_0x800000) == UNKNOWN_EFFECT_0x800000) || (player->unk_044 & UNK_044_UNUSED_0x800)) {
         player->unk_050[screenId] = 0;
     }
-    if (((player->effects & MIDAIR_EFFECT) == MIDAIR_EFFECT) && ((player->unk_0CA & UNK_0CA_HELD_BY_LAKITU) == UNK_0CA_HELD_BY_LAKITU)) {
+    if (((player->effects & MIDAIR_EFFECT) == MIDAIR_EFFECT) && ((player->lakitu_props & HELD_BY_LAKITU) == HELD_BY_LAKITU)) {
         player->unk_050[screenId] = 0;
     }
     var_a0 = (player->unk_048[screenId] + player->rotation[1] + player->unk_0C0);
@@ -946,7 +946,7 @@ void func_80029B4C(Player* player, UNUSED f32 arg1, f32 arg2, UNUSED f32 arg3) {
     temp_f2_3 = ((gCharacterSize[player->characterId] * 18.0f) + 1.0f) * player->size;
     temp_f0_2 = player->unk_23C - player->unk_230;
     player->unk_206 = -atan1s(temp_f0_2 / temp_f2_3);
-    if (((player->unk_0CA & UNK_0CA_HELD_BY_LAKITU) == UNK_0CA_HELD_BY_LAKITU) || (player->effects & MIDAIR_EFFECT)) {
+    if (((player->lakitu_props & HELD_BY_LAKITU) == HELD_BY_LAKITU) || (player->effects & MIDAIR_EFFECT)) {
         player->unk_206 = 0;
     }
     if ((player->effects & MIDAIR_EFFECT) != MIDAIR_EFFECT) {
@@ -962,7 +962,7 @@ void func_80029B4C(Player* player, UNUSED f32 arg1, f32 arg2, UNUSED f32 arg3) {
         }
         move_s16_towards(&player->slopeAccel, temp_v0, 0.5f);
     }
-    if (((player->effects & MIDAIR_EFFECT) == MIDAIR_EFFECT) && ((player->unk_0CA & UNK_0CA_HELD_BY_LAKITU) == UNK_0CA_HELD_BY_LAKITU)) {
+    if (((player->effects & MIDAIR_EFFECT) == MIDAIR_EFFECT) && ((player->lakitu_props & HELD_BY_LAKITU) == HELD_BY_LAKITU)) {
         player->slopeAccel = (s16) ((s32) player->unk_D9C);
     }
     player->surfaceType = get_surface_type(player->collision.meshIndexZX) & 0xFF;
@@ -1424,7 +1424,7 @@ void apply_triggers(Player* player, s8 playerId, UNUSED s8 screenId) {
 }
 
 void func_8002B5C0(Player* player, UNUSED s8 playerId, UNUSED s8 screenId) {
-    if (((player->unk_0CA & UNK_0CA_LAKITU_SCENE) != 0) || ((player->unk_0CA & UNK_0CA_HELD_BY_LAKITU) != 0)) {
+    if (((player->lakitu_props & LAKITU_SCENE) != 0) || ((player->lakitu_props & HELD_BY_LAKITU) != 0)) {
         player->triggers &= ALL_TRIGGERS & ~(HIT_TRIGGERS | ANY_BOOST_TRIGGERS | RACING_SPINOUT_TRIGGERS | STATE_TRANSITION_TRIGGERS);
     }
     // Green shell
@@ -1788,7 +1788,7 @@ void func_8002C17C(Player* player, s8 playerId) {
             } else if (D_80165330[playerId] == 0) {
                 gCopyNearestPathPointByPlayerId[playerId] = gNearestPathPointByPlayerId[playerId];
                 gCopyPathIndexByPlayerId[playerId] = gPathIndexByPlayerId[playerId];
-            } else if (!((player->effects & MIDAIR_EFFECT) || (player->unk_0CA & UNK_0CA_LAKITU_RETRIEVAL))) {
+            } else if (!((player->effects & MIDAIR_EFFECT) || (player->lakitu_props & LAKITU_RETRIEVAL))) {
                 D_80165330[playerId] = 0;
             }
             break;
@@ -1832,15 +1832,15 @@ void func_8002C4F8(Player* player, s8 playerIndex) {
     }
     if ((player->boundingBoxSize < (D_801652A0[playerIndex] - player->pos[1])) &&
         (player->collision.surfaceDistance[2] >= 600.0f)) {
-        player->unk_0CA |= UNK_0CA_LAKITU_RETRIEVAL;
+        player->lakitu_props |= LAKITU_RETRIEVAL;
     }
     if (player->collision.surfaceDistance[2] >= 600.0f) {
-        player->unk_0CA |= UNK_0CA_WENT_OVER_OOB;
+        player->lakitu_props |= WENT_OVER_OOB;
     } else if ((player->effects & MIDAIR_EFFECT) != MIDAIR_EFFECT) {
-        player->unk_0CA &= ~UNK_0CA_WENT_OVER_OOB;
+        player->lakitu_props &= ~WENT_OVER_OOB;
     }
-    if ((player->type & PLAYER_CPU) && ((func_802ABDF4(player->collision.meshIndexZX) != 0) || (player->unk_0CA & UNK_0CA_LAKITU_RETRIEVAL))) {
-        if (!(player->unk_0CA & UNK_0CA_HELD_BY_LAKITU) && !(player->unk_0CA & UNK_0CA_LAKITU_SCENE) && !(player->effects & LOST_RACE_EFFECT)) {
+    if ((player->type & PLAYER_CPU) && ((func_802ABDF4(player->collision.meshIndexZX) != 0) || (player->lakitu_props & LAKITU_RETRIEVAL))) {
+        if (!(player->lakitu_props & HELD_BY_LAKITU) && !(player->lakitu_props & LAKITU_SCENE) && !(player->effects & LOST_RACE_EFFECT)) {
             func_80090778(player);
             func_80090868(player);
         }
@@ -1905,7 +1905,7 @@ void func_8002C954(Player* player, s8 playerId, Vec3f velocity) {
          ((((temp_f0 >= 20.0f) || (temp_f0 < (-1.0f))) && ((player->effects & TERRAIN_TUMBLE_EFFECT) == 0)) &&
           (player->effects & MIDAIR_EFFECT)) ||
          ((player->collision.unk34 == 0) && ((player->effects & TERRAIN_TUMBLE_EFFECT) == 0))) &&
-        (((player->unk_0CA & UNK_0CA_HELD_BY_LAKITU) == 0) || (!(player->unk_0CA & UNK_0CA_LAKITU_SCENE)))) {
+        (((player->lakitu_props & HELD_BY_LAKITU) == 0) || (!(player->lakitu_props & LAKITU_SCENE)))) {
         func_8008F494(player, playerId);
     }
     if ((player->unk_046 & 0x20) != 0x20) {
@@ -1953,7 +1953,7 @@ void func_8002C954(Player* player, s8 playerId, Vec3f velocity) {
 }
 
 void apply_effect(Player* player, s8 playerIndex, s8 arg2) {
-    if (((player->unk_0CA & UNK_0CA_HELD_BY_LAKITU) == UNK_0CA_HELD_BY_LAKITU) || ((player->unk_0CA & UNK_0CA_LAKITU_SCENE) == UNK_0CA_LAKITU_SCENE)) {
+    if (((player->lakitu_props & HELD_BY_LAKITU) == HELD_BY_LAKITU) || ((player->lakitu_props & LAKITU_SCENE) == LAKITU_SCENE)) {
         func_80090970(player, playerIndex, arg2);
     }
     if ((player->effects & BANANA_NEAR_SPINOUT_EFFECT) == BANANA_NEAR_SPINOUT_EFFECT) {
@@ -2217,9 +2217,9 @@ void func_8002D268(Player* player, UNUSED Camera* camera, s8 screenId, s8 player
         (((((f64) ((sp184[1] + gravityY) + sp160[1])) - (newVelocity[1] * (0.12 * ((f64) player->kartFriction)))) /
           6000.0) /
          ((f64) player->unk_DAC));
-    if (((((player->unk_0CA & UNK_0CA_HELD_BY_LAKITU) == UNK_0CA_HELD_BY_LAKITU) || ((player->unk_0CA & UNK_0CA_LAKITU_SCENE) == UNK_0CA_LAKITU_SCENE)) ||
+    if (((((player->lakitu_props & HELD_BY_LAKITU) == HELD_BY_LAKITU) || ((player->lakitu_props & LAKITU_SCENE) == LAKITU_SCENE)) ||
          ((player->effects & SQUISH_EFFECT) == SQUISH_EFFECT)) ||
-        (player->unk_0CA & UNK_0CA_LAKITU_RETRIEVAL)) {
+        (player->lakitu_props & LAKITU_RETRIEVAL)) {
         newVelocity[0] = 0.0f;
         newVelocity[1] = 0.0f;
         newVelocity[2] = 0.0f;
@@ -2239,9 +2239,9 @@ void func_8002D268(Player* player, UNUSED Camera* camera, s8 screenId, s8 player
     nextY = posY + player->velocity[1];
     nextZ = posZ + player->velocity[2] + D_8018CE10[playerId].unk_04[2];
 
-    if (((((player->unk_0CA & UNK_0CA_HELD_BY_LAKITU) != UNK_0CA_HELD_BY_LAKITU) && ((player->unk_0CA & UNK_0CA_LAKITU_SCENE) != UNK_0CA_LAKITU_SCENE)) &&
+    if (((((player->lakitu_props & HELD_BY_LAKITU) != HELD_BY_LAKITU) && ((player->lakitu_props & LAKITU_SCENE) != LAKITU_SCENE)) &&
          ((player->effects & SQUISH_EFFECT) != SQUISH_EFFECT)) &&
-        (!(player->unk_0CA & UNK_0CA_LAKITU_RETRIEVAL))) {
+        (!(player->lakitu_props & LAKITU_RETRIEVAL))) {
         func_8002AAC0(player);
         nextY += player->kartHopVelocity;
         nextY -= 0.02;
@@ -2339,7 +2339,7 @@ void func_8002D268(Player* player, UNUSED Camera* camera, s8 screenId, s8 player
     }
     if (((!(player->effects & MIDAIR_EFFECT)) && (func_802ABDB8(player->collision.meshIndexZX) != 0)) &&
         ((player->effects & TERRAIN_TUMBLE_EFFECT) != TERRAIN_TUMBLE_EFFECT)) {
-        if ((!(player->unk_0CA & UNK_0CA_HELD_BY_LAKITU)) || (!(player->unk_0CA & UNK_0CA_LAKITU_SCENE))) {
+        if ((!(player->lakitu_props & HELD_BY_LAKITU)) || (!(player->lakitu_props & LAKITU_SCENE))) {
             func_8008F494(player, playerId);
         }
     } else if (((!(player->effects & MIDAIR_EFFECT)) && (func_802ABDB8(player->collision.meshIndexZX) == 0)) &&
@@ -2504,7 +2504,7 @@ void func_8002E594(Player* player, UNUSED Camera* camera, s8 screenId, s8 player
     }
     newVelocity[1] += (((((spEC[1] + gravityY) + spD4[1])) - (newVelocity[1] * (0.12 * player->kartFriction))) / 6000) / player->unk_DAC;
 
-    if (((player->unk_0CA & UNK_0CA_HELD_BY_LAKITU) == UNK_0CA_HELD_BY_LAKITU) || ((player->unk_0CA & UNK_0CA_LAKITU_SCENE) == UNK_0CA_LAKITU_SCENE)) {
+    if (((player->lakitu_props & HELD_BY_LAKITU) == HELD_BY_LAKITU) || ((player->lakitu_props & LAKITU_SCENE) == LAKITU_SCENE)) {
         newVelocity[0] = 0.0f;
         newVelocity[1] = 0.0f;
         newVelocity[2] = 0.0f;
@@ -2626,7 +2626,7 @@ void func_8002E594(Player* player, UNUSED Camera* camera, s8 screenId, s8 player
     if (((func_802ABDB8(player->collision.meshIndexZX) != 0) &&
          ((player->effects & TERRAIN_TUMBLE_EFFECT) != TERRAIN_TUMBLE_EFFECT)) &&
         (((player->speed / 18.0f) * 216.0f) >= 20.0f)) {
-        if ((!(player->unk_0CA & UNK_0CA_HELD_BY_LAKITU)) || (!(player->unk_0CA & UNK_0CA_LAKITU_SCENE))) {
+        if ((!(player->lakitu_props & HELD_BY_LAKITU)) || (!(player->lakitu_props & LAKITU_SCENE))) {
             func_8008F494(player, playerId);
         }
     } else if (((!(player->effects & MIDAIR_EFFECT)) && (func_802ABDB8(player->collision.meshIndexZX) == 0)) &&
@@ -2980,7 +2980,7 @@ f32 func_80030150(Player* player, s8 playerIndex) {
                 var_f0 += D_800E2E90[player->characterId][player->tyres[FRONT_LEFT].surfaceType];
             }
         }
-        if (((player->effects & MIDAIR_EFFECT) != MIDAIR_EFFECT) && ((player->unk_0CA & UNK_0CA_HELD_BY_LAKITU) != UNK_0CA_HELD_BY_LAKITU)) {
+        if (((player->effects & MIDAIR_EFFECT) != MIDAIR_EFFECT) && ((player->lakitu_props & HELD_BY_LAKITU) != HELD_BY_LAKITU)) {
             temp_lo = player->slopeAccel / 182;
             if (var_f2 >= 20.0f) {
                 if ((temp_lo > 0x11) || (temp_lo < -0x11)) {
@@ -3071,7 +3071,7 @@ f32 func_80030150(Player* player, s8 playerIndex) {
     if (var_f2 < 0.0f) {
         var_f2 = 0.0f;
     }
-    if (((player->unk_0CA & UNK_0CA_HELD_BY_LAKITU) == UNK_0CA_HELD_BY_LAKITU) || ((player->unk_0CA & UNK_0CA_LAKITU_SCENE) == UNK_0CA_LAKITU_SCENE) ||
+    if (((player->lakitu_props & HELD_BY_LAKITU) == HELD_BY_LAKITU) || ((player->lakitu_props & LAKITU_SCENE) == LAKITU_SCENE) ||
         ((player->type & PLAYER_START_SEQUENCE) == PLAYER_START_SEQUENCE)) {
         return (1.0f - player->unk_104) * var_f2;
     }
@@ -3095,7 +3095,7 @@ void func_80030A34(Player* player) {
     f32 var_f0;
     f32 var_f2;
 
-    if (((player->unk_0CA & UNK_0CA_HELD_BY_LAKITU) != UNK_0CA_HELD_BY_LAKITU) && ((player->unk_0CA & UNK_0CA_LAKITU_SCENE) != UNK_0CA_LAKITU_SCENE)) {
+    if (((player->lakitu_props & HELD_BY_LAKITU) != HELD_BY_LAKITU) && ((player->lakitu_props & LAKITU_SCENE) != LAKITU_SCENE)) {
         if ((((player->speed / 18.0f) * 216.0f) >= 8.0f) && (player->unk_DB4.unkC < 1.0f)) {
             switch (player->surfaceType) { /* irregular */
                 case ASPHALT:
@@ -4662,7 +4662,7 @@ void handle_a_press_for_player_during_race(Player* player, struct Controller* co
         ((player->type & PLAYER_CPU) != PLAYER_CPU)) {
         // If not start sequence
         if ((player->type & PLAYER_START_SEQUENCE) != PLAYER_START_SEQUENCE) {
-            if (((player->unk_0CA & UNK_0CA_HELD_BY_LAKITU) == UNK_0CA_HELD_BY_LAKITU) || ((player->unk_0CA & UNK_0CA_LAKITU_SCENE) == UNK_0CA_LAKITU_SCENE)) {
+            if (((player->lakitu_props & HELD_BY_LAKITU) == HELD_BY_LAKITU) || ((player->lakitu_props & LAKITU_SCENE) == LAKITU_SCENE)) {
                 if (controller->button & A_BUTTON) {
                     player_accelerate(player);
                 } else {

--- a/src/player_controller.c
+++ b/src/player_controller.c
@@ -3405,7 +3405,7 @@ void player_accelerate_alternative(Player* player) {
     if (!((player->effects & MIDAIR_EFFECT)) || ((player->effects & LIGHTNING_EFFECT))) {
         player->unk_08C = (player->currentSpeed * player->currentSpeed) / 25.0f;
     }
-    player->kartProps |= PRESS_A;
+    player->kartProps |= THROTTLE;
     // Hacky way to check for START_SPINOUT_TRIGGER
     if ((player->triggers * 8) < 0) {
         func_8008F104(player, player_index);
@@ -3430,7 +3430,7 @@ void player_decelerate_alternative(Player* player, f32 speed) {
     if ((player->effects & MIDAIR_EFFECT) != MIDAIR_EFFECT) {
         player->unk_08C = (player->currentSpeed * player->currentSpeed) / 25.0f;
     }
-    player->kartProps &= ~PRESS_A;
+    player->kartProps &= ~THROTTLE;
     // Hacky way to check for START_SPINOUT_TRIGGER
     if ((player->triggers * 8) < 0) {
         func_8008F104(player, player_index);
@@ -3673,7 +3673,7 @@ void player_accelerate_during_start_sequence(Player* player) {
         } else {
             var_v0 = 8;
         }
-        if ((time_delta < var_v0) && ((player->kartProps & PRESS_A) != PRESS_A)) {
+        if ((time_delta < var_v0) && ((player->kartProps & THROTTLE) != THROTTLE)) {
             player->triggers |= START_BOOST_TRIGGER;
         } else if ((player->topSpeed * 0.9f) <= player->currentSpeed) {
             if ((player->triggers & START_BOOST_TRIGGER) != START_BOOST_TRIGGER) {
@@ -3682,7 +3682,7 @@ void player_accelerate_during_start_sequence(Player* player) {
             }
         }
     }
-    player->kartProps |= PRESS_A;
+    player->kartProps |= THROTTLE;
     player->unk_098 = (player->currentSpeed * player->currentSpeed) / 25.0f;
 }
 
@@ -3701,7 +3701,7 @@ void player_decelerate_during_start_sequence(Player* player, f32 speedReduction)
         player->triggers &= ~START_SPINOUT_TRIGGER;
     }
     player->triggers &= ~START_BOOST_TRIGGER;
-    player->kartProps &= ~PRESS_A;
+    player->kartProps &= ~THROTTLE;
     player->unk_098 = (player->currentSpeed * player->currentSpeed) / 25.0f;
 }
 
@@ -3791,7 +3791,7 @@ void player_accelerate_global(Player* player, s32 playerIndex) {
     if (((player->topSpeed * 0.9) <= gPlayerCurrentSpeed[playerIndex]) && (gPlayerCurrentSpeed[playerIndex] <= (player->topSpeed * 1.0))) {
         gPlayerCurrentSpeed[playerIndex] += gKartAccelerationTables[player->characterId][9] * 2.8;
     }
-    player->kartProps |= PRESS_A;
+    player->kartProps |= THROTTLE;
     if (gPlayerCurrentSpeed[playerIndex] < 0.0f) {
         gPlayerCurrentSpeed[playerIndex] = 0.0f;
     }
@@ -3799,7 +3799,7 @@ void player_accelerate_global(Player* player, s32 playerIndex) {
 }
 
 void player_decelerate_global(Player* player, f32 speedReduction, s32 playerIndex) {
-    player->kartProps &= ~PRESS_A;
+    player->kartProps &= ~THROTTLE;
     gPlayerCurrentSpeed[playerIndex] -= speedReduction;
     if (gPlayerCurrentSpeed[playerIndex] <= 0.0f) {
         gPlayerCurrentSpeed[playerIndex] = 0.0f;
@@ -4909,7 +4909,7 @@ void func_80038BE4(Player* player, s16 arg1) {
     if (player->currentSpeed >= 250.0f) {
         player->currentSpeed = 250.0f;
     }
-    player->kartProps |= PRESS_A;
+    player->kartProps |= THROTTLE;
     player->unk_08C = (player->currentSpeed * player->currentSpeed) / 25.0f;
 }
 

--- a/src/player_controller.c
+++ b/src/player_controller.c
@@ -544,7 +544,7 @@ void func_80028864(Player* player, Camera* camera, s8 playerId, s8 screenId) {
                 ((player->effects & UNKNOWN_EFFECT_0x800000) == UNKNOWN_EFFECT_0x800000) ||
                 ((player->effects & EXPLOSION_CRASH_EFFECT) == EXPLOSION_CRASH_EFFECT) ||
                 ((player->effects & HIT_BY_STAR_EFFECT) == HIT_BY_STAR_EFFECT) ||
-                ((player->effects & LIGHTNING_STRIKE_EFFECT) == LIGHTNING_STRIKE_EFFECT) || (player->unk_044 & UNK_044_UNUSED_0x800)) {
+                ((player->effects & LIGHTNING_STRIKE_EFFECT) == LIGHTNING_STRIKE_EFFECT) || (player->kartProps & UNUSED_0x800)) {
                 func_8002E594(player, camera, screenId, playerId);
             } else {
                 func_8002D268(player, camera, screenId, playerId);
@@ -577,7 +577,7 @@ void func_80028C44(Player* player, Camera* camera, s8 playerId, s8 screenId) {
             ((player->effects & EXPLOSION_CRASH_EFFECT) == EXPLOSION_CRASH_EFFECT) ||
             ((player->effects & HIT_BY_STAR_EFFECT) == HIT_BY_STAR_EFFECT) ||
             ((player->effects & LIGHTNING_STRIKE_EFFECT) == LIGHTNING_STRIKE_EFFECT) ||
-            ((player->unk_044 & UNK_044_UNUSED_0x800) != 0)) {
+            ((player->kartProps & UNUSED_0x800) != 0)) {
             func_8002E594(player, camera, screenId, playerId);
         } else {
             func_8002D268(player, camera, screenId, playerId);
@@ -602,7 +602,7 @@ void func_80028D3C(Player* player, Camera* camera, s8 playerId, s8 screenId) {
             ((player->effects & EXPLOSION_CRASH_EFFECT) == EXPLOSION_CRASH_EFFECT) ||
             ((player->effects & HIT_BY_STAR_EFFECT) == HIT_BY_STAR_EFFECT) ||
             ((player->effects & LIGHTNING_STRIKE_EFFECT) == LIGHTNING_STRIKE_EFFECT) ||
-            ((player->unk_044 & UNK_044_UNUSED_0x800) != 0)) {
+            ((player->kartProps & UNUSED_0x800) != 0)) {
             func_8002E594(player, camera, screenId, playerId);
         } else {
             func_8002D268(player, camera, screenId, playerId);
@@ -774,7 +774,7 @@ void func_8002934C(Player* player, Camera* camera, s8 screenId, s8 playerId) {
         ((player->effects & DRIVING_SPINOUT_EFFECT) != DRIVING_SPINOUT_EFFECT) &&
         ((player->effects & UNKNOWN_EFFECT_0x80000) != UNKNOWN_EFFECT_0x80000) &&
         ((player->effects & UNKNOWN_EFFECT_0x800000) != UNKNOWN_EFFECT_0x800000) &&
-        ((player->effects & LIGHTNING_STRIKE_EFFECT) != LIGHTNING_STRIKE_EFFECT) && (!(player->unk_044 & UNK_044_UNUSED_0x800))) {
+        ((player->effects & LIGHTNING_STRIKE_EFFECT) != LIGHTNING_STRIKE_EFFECT) && (!(player->kartProps & UNUSED_0x800))) {
         if (var_a0 < 0x51) {
             var_a1 = 0x208;
             var_t0 = 0;
@@ -787,7 +787,7 @@ void func_8002934C(Player* player, Camera* camera, s8 screenId, s8 playerId) {
         var_t0 = 0;
     }
     if (((player->effects & UNKNOWN_EFFECT_0x80000) == UNKNOWN_EFFECT_0x80000) ||
-        ((player->effects & UNKNOWN_EFFECT_0x800000) == UNKNOWN_EFFECT_0x800000) || (player->unk_044 & UNK_044_UNUSED_0x800)) {
+        ((player->effects & UNKNOWN_EFFECT_0x800000) == UNKNOWN_EFFECT_0x800000) || (player->kartProps & UNUSED_0x800)) {
         player->unk_050[screenId] = 0;
     }
     if (((player->effects & MIDAIR_EFFECT) == MIDAIR_EFFECT) && ((player->lakitu_props & HELD_BY_LAKITU) == HELD_BY_LAKITU)) {
@@ -798,7 +798,7 @@ void func_8002934C(Player* player, Camera* camera, s8 screenId, s8 playerId) {
         ((player->effects & DRIVING_SPINOUT_EFFECT) == DRIVING_SPINOUT_EFFECT) ||
         ((player->effects & UNKNOWN_EFFECT_0x80000) == UNKNOWN_EFFECT_0x80000) ||
         ((player->effects & UNKNOWN_EFFECT_0x800000) == UNKNOWN_EFFECT_0x800000) ||
-        ((player->effects & LIGHTNING_STRIKE_EFFECT) == LIGHTNING_STRIKE_EFFECT) || (player->unk_044 & UNK_044_UNUSED_0x800)) {
+        ((player->effects & LIGHTNING_STRIKE_EFFECT) == LIGHTNING_STRIKE_EFFECT) || (player->kartProps & UNUSED_0x800)) {
         if (var_a0 >= 0x7FF9) {
             var_a0 = -var_a0;
             var_a0 /= var_a1;
@@ -820,7 +820,7 @@ void func_8002934C(Player* player, Camera* camera, s8 screenId, s8 playerId) {
     }
     if ((player->effects & BANANA_SPINOUT_EFFECT) || (player->effects & DRIVING_SPINOUT_EFFECT) ||
         (player->effects & UNKNOWN_EFFECT_0x80000) || (player->effects & UNKNOWN_EFFECT_0x800000) ||
-        (player->effects & LIGHTNING_STRIKE_EFFECT) || (player->unk_044 & UNK_044_UNUSED_0x800)) {
+        (player->effects & LIGHTNING_STRIKE_EFFECT) || (player->kartProps & UNUSED_0x800)) {
 
         if ((player->animFrameSelector[screenId]) >= 0x14) {
             player->animFrameSelector[screenId] = 0;
@@ -830,7 +830,7 @@ void func_8002934C(Player* player, Camera* camera, s8 screenId, s8 playerId) {
         player->animGroupSelector[screenId] = 4;
     }
     if (((player->effects & UNKNOWN_EFFECT_0x80000) == UNKNOWN_EFFECT_0x80000) ||
-        ((player->effects & UNKNOWN_EFFECT_0x800000) == UNKNOWN_EFFECT_0x800000) || (player->unk_044 & UNK_044_UNUSED_0x800)) {
+        ((player->effects & UNKNOWN_EFFECT_0x800000) == UNKNOWN_EFFECT_0x800000) || (player->kartProps & UNUSED_0x800)) {
 
         player->animGroupSelector[screenId] = 4;
     }
@@ -1264,7 +1264,7 @@ void func_8002AB70(Player* player) {
     if (player->effects & UNKNOWN_EFFECT_0x80000) {
         player->kartGravity = 1500.0f;
     }
-    if ((player->unk_044 & UNK_044_UNUSED_0x800) != 0) {
+    if ((player->kartProps & UNUSED_0x800) != 0) {
         player->kartGravity = 1900.0f;
     }
     if ((player->effects & UNKNOWN_EFFECT_0x800000) == UNKNOWN_EFFECT_0x800000) {
@@ -1298,7 +1298,7 @@ void func_8002AE38(Player* player, s8 arg1, f32 arg2, f32 arg3, f32 arg4, f32 ar
     sp28 = (sins(-player->rotation[1]) * player->speed) + arg2;
     temp_f16 = (coss(-player->rotation[1]) * player->speed) + arg3;
     if (((player->effects & BANANA_NEAR_SPINOUT_EFFECT) != BANANA_NEAR_SPINOUT_EFFECT) &&
-        ((player->effects & DRIFTING_EFFECT) != DRIFTING_EFFECT) && !(player->unk_044 & UNK_044_DRIVING_SPINOUT) &&
+        ((player->effects & DRIFTING_EFFECT) != DRIFTING_EFFECT) && !(player->kartProps & DRIVING_SPINOUT) &&
         ((((player->speed / 18.0f) * 216.0f) <= 8.0f) ||
          (((player->unk_07C >> 0x10) < 5) && ((player->unk_07C >> 0x10) > -5)))) {
         if ((player->effects & AB_SPIN_EFFECT) == AB_SPIN_EFFECT) {
@@ -1440,7 +1440,7 @@ void func_8002B5C0(Player* player, UNUSED s8 playerId, UNUSED s8 screenId) {
     if ((player->effects & BANANA_NEAR_SPINOUT_EFFECT) == BANANA_NEAR_SPINOUT_EFFECT) {
         player->triggers &= ALL_TRIGGERS & ~(ANY_BOOST_TRIGGERS | RACING_SPINOUT_TRIGGERS | STATE_TRANSITION_TRIGGERS);
     }
-    if ((player->unk_044 & UNK_044_DRIVING_SPINOUT) != 0) {
+    if ((player->kartProps & DRIVING_SPINOUT) != 0) {
         player->triggers &= ALL_TRIGGERS & ~(ANY_BOOST_TRIGGERS | RACING_SPINOUT_TRIGGERS | STATE_TRANSITION_TRIGGERS);
     }
     //unclear
@@ -1500,7 +1500,7 @@ void func_8002B830(Player* player, s8 playerId, s8 screenId) {
     if (player->triggers != 0) {
         apply_triggers(player, playerId, screenId);
     }
-    if ((player->unk_044 & UNK_044_UNUSED_0x400) != 0) { //can never be true
+    if ((player->kartProps & UNUSED_0x400) != 0) { //can never be true
         func_800911B4(player, playerId);
     }
 }
@@ -1858,7 +1858,7 @@ void func_8002C7E4(Player* player, s8 playerIndex, s8 arg2) {
             if ((player->effects & MUSHROOM_EFFECT) != MUSHROOM_EFFECT) {
                 func_8002B9CC(player, playerIndex, arg2);
             }
-            player->unk_044 &= ~UNK_044_BACK_UP;
+            player->kartProps &= ~BACK_UP;
             player->unk_046 |= 1;
             player->unk_046 |= 8;
             if ((player->type & PLAYER_HUMAN) == PLAYER_HUMAN) {
@@ -1878,7 +1878,7 @@ void func_8002C7E4(Player* player, s8 playerIndex, s8 arg2) {
     if ((player->effects & ENEMY_BONK_EFFECT) == ENEMY_BONK_EFFECT) {
         player->effects &= ~ENEMY_BONK_EFFECT;
         player->unk_10C = 1;
-        player->unk_044 &= ~UNK_044_BACK_UP;
+        player->kartProps &= ~BACK_UP;
         return;
     }
     player->unk_046 &= ~0x0001;
@@ -1959,7 +1959,7 @@ void apply_effect(Player* player, s8 playerIndex, s8 arg2) {
     if ((player->effects & BANANA_NEAR_SPINOUT_EFFECT) == BANANA_NEAR_SPINOUT_EFFECT) {
         func_8008CEB0(player, playerIndex);
     }
-    if (player->unk_044 & UNK_044_DRIVING_SPINOUT) {
+    if (player->kartProps & DRIVING_SPINOUT) {
         func_8008D170(player, playerIndex);
     }
     if ((player->effects & MUSHROOM_EFFECT) == MUSHROOM_EFFECT) {
@@ -2020,7 +2020,7 @@ void apply_effect(Player* player, s8 playerIndex, s8 arg2) {
             func_8008FCDC(player, playerIndex);
         }
     }
-    if (player->unk_044 & UNK_044_UNUSED_0x800) { // never true
+    if (player->kartProps & UNUSED_0x800) { // never true
         func_80091298(player, playerIndex);
     }
 }
@@ -2124,7 +2124,7 @@ void func_8002D268(Player* player, UNUSED Camera* camera, s8 screenId, s8 player
     func_80037BB4(player, sp160);
     func_8002AB70(player);
     func_8002FCA8(player, playerId);
-    if (player->unk_044 & UNK_044_BACK_UP) {
+    if (player->kartProps & BACK_UP) {
         player->unk_064[0] *= -1.0f;
         player->unk_064[2] *= -1.0f;
     }
@@ -2159,9 +2159,9 @@ void func_8002D268(Player* player, UNUSED Camera* camera, s8 screenId, s8 player
     temp_f2_2 = ((player->oldPos[2] - player->pos[2]) * coss(player->rotation[1] + player->unk_0C0)) +
                 (-(player->oldPos[0] - player->pos[0]) * sins(player->rotation[1] + player->unk_0C0));
     if (temp_f2_2 > 0.1) {
-        player->unk_044 |= UNK_044_MOVE_BACKWARDS;
+        player->kartProps |= MOVE_BACKWARDS;
     } else {
-        player->unk_044 &= ~UNK_044_MOVE_BACKWARDS;
+        player->kartProps &= ~MOVE_BACKWARDS;
     }
     if (((player->unk_08C <= 0.0f) &&
          ((temp_v0_3 = player->effects, (temp_v0_3 & BRAKING_EFFECT) == BRAKING_EFFECT))) &&
@@ -2224,8 +2224,8 @@ void func_8002D268(Player* player, UNUSED Camera* camera, s8 screenId, s8 player
         newVelocity[1] = 0.0f;
         newVelocity[2] = 0.0f;
     }
-    if ((player->unk_044 & UNK_044_LOSE_GP_RACE) == UNK_044_LOSE_GP_RACE) {
-        player->unk_044 &= ~UNK_044_LOSE_GP_RACE;
+    if ((player->kartProps & LOSE_GP_RACE) == LOSE_GP_RACE) {
+        player->kartProps &= ~LOSE_GP_RACE;
     }
 
     posX = player->pos[0];
@@ -2251,7 +2251,7 @@ void func_8002D268(Player* player, UNUSED Camera* camera, s8 screenId, s8 player
     player->unk_058 = 0.0f;
     player->unk_060 = 0.0f;
     player->unk_05C = 1.0f;
-    if ((player->unk_044 & UNK_044_BACK_UP) != UNK_044_BACK_UP) {
+    if ((player->kartProps & BACK_UP) != BACK_UP) {
         calculate_orientation_matrix(player->orientationMatrix, player->unk_058, player->unk_05C, player->unk_060,
                                      player->rotation[1]);
     } else {
@@ -2281,7 +2281,7 @@ void func_8002D268(Player* player, UNUSED Camera* camera, s8 screenId, s8 player
                 func_800CADD0((u8) playerId, ((f32) player->unk_0C2) / 35.0f);
             }
             if ((player->type & PLAYER_HUMAN) == PLAYER_HUMAN) {
-                player->unk_044 |= UNK_044_POST_TUMBLE_GAS;
+                player->kartProps |= POST_TUMBLE_GAS;
             }
         }
         if (((player->unk_0C2 < 0x23) && (player->unk_0C2 >= 0x1C)) && (((player->speed / 18.0f) * 216.0f) >= 20.0f)) {
@@ -2292,7 +2292,7 @@ void func_8002D268(Player* player, UNUSED Camera* camera, s8 screenId, s8 player
                 func_800CADD0((u8) playerId, ((f32) player->unk_0C2) / 35.0f);
             }
             if ((player->type & PLAYER_HUMAN) == PLAYER_HUMAN) {
-                player->unk_044 |= UNK_044_POST_TUMBLE_GAS;
+                player->kartProps |= POST_TUMBLE_GAS;
             }
         }
         if (((player->unk_0C2 < 0x1C) && (player->unk_0C2 >= 4)) && (((player->speed / 18.0f) * 216.0f) >= 20.0f)) {
@@ -2389,7 +2389,7 @@ void func_8002D268(Player* player, UNUSED Camera* camera, s8 screenId, s8 player
             player->speed = gKartTopSpeedTable[player->characterId];
         }
     }
-    if ((player->unk_044 & UNK_044_BACK_UP) == UNK_044_BACK_UP) {
+    if ((player->kartProps & BACK_UP) == BACK_UP) {
         if (player->speed > 1) {
             temp = 1 / player->speed;
             player->velocity[0] *= temp;
@@ -2449,7 +2449,7 @@ void func_8002E594(Player* player, UNUSED Camera* camera, s8 screenId, s8 player
            ((player->effects & UNKNOWN_EFFECT_0x80000) == UNKNOWN_EFFECT_0x80000)) ||
           ((player->effects & UNKNOWN_EFFECT_0x800000) == UNKNOWN_EFFECT_0x800000)) ||
          ((player->effects & LIGHTNING_STRIKE_EFFECT) == LIGHTNING_STRIKE_EFFECT)) ||
-        (player->unk_044 & UNK_044_UNUSED_0x800)) {
+        (player->kartProps & UNUSED_0x800)) {
         sp46 = 1;
     } else {
         sp46 = 0;
@@ -2548,7 +2548,7 @@ void func_8002E594(Player* player, UNUSED Camera* camera, s8 screenId, s8 player
                     func_800CADD0((u8) playerId, ((f32) player->unk_0C2) / 50.0f);
                 }
                 if ((player->type & PLAYER_HUMAN) == PLAYER_HUMAN) {
-                    player->unk_044 |= UNK_044_POST_TUMBLE_GAS;
+                    player->kartProps |= POST_TUMBLE_GAS;
                 }
             }
             if (((player->unk_0C2 < 0x1C) && (player->unk_0C2 >= 0xA)) &&
@@ -2560,7 +2560,7 @@ void func_8002E594(Player* player, UNUSED Camera* camera, s8 screenId, s8 player
                     func_800CADD0((u8) playerId, ((f32) player->unk_0C2) / 50.0f);
                 }
                 if ((player->type & PLAYER_HUMAN) == PLAYER_HUMAN) {
-                    player->unk_044 |= UNK_044_POST_TUMBLE_GAS;
+                    player->kartProps |= POST_TUMBLE_GAS;
                 }
             }
             player->unk_0C2 = 0;
@@ -2585,7 +2585,7 @@ void func_8002E594(Player* player, UNUSED Camera* camera, s8 screenId, s8 player
                     player->kartHopJerk = 0.06f;
                     player->kartHopAcceleration = 0.0f;
                     if ((player->type & PLAYER_HUMAN) == PLAYER_HUMAN) {
-                        player->unk_044 |= UNK_044_POST_TUMBLE_GAS;
+                        player->kartProps |= POST_TUMBLE_GAS;
                     }
                 }
             } else {
@@ -2692,7 +2692,7 @@ void control_cpu_movement(Player* player, UNUSED Camera* camera, s8 screenId, s8
     f32 topSpeedMultiplier;
     f32 nextY;
     player->effects |= LOST_RACE_EFFECT;
-    player->unk_044 |= UNK_044_LOSE_GP_RACE;
+    player->kartProps |= LOSE_GP_RACE;
     nextY = gPlayerPathY[playerId];
     player->unk_204 = 0;
     player->effects &= ~DRIFTING_EFFECT;
@@ -3366,7 +3366,7 @@ void player_accelerate_alternative(Player* player) {
     if (!((player->effects & MIDAIR_EFFECT)) || ((player->effects & LIGHTNING_EFFECT))) {
         player->unk_08C = (player->currentSpeed * player->currentSpeed) / 25.0f;
     }
-    player->unk_044 |= UNK_044_PRESS_A;
+    player->kartProps |= PRESS_A;
     // Hacky way to check for START_SPINOUT_TRIGGER
     if ((player->triggers * 8) < 0) {
         func_8008F104(player, player_index);
@@ -3391,7 +3391,7 @@ void player_decelerate_alternative(Player* player, f32 speed) {
     if ((player->effects & MIDAIR_EFFECT) != MIDAIR_EFFECT) {
         player->unk_08C = (player->currentSpeed * player->currentSpeed) / 25.0f;
     }
-    player->unk_044 &= ~UNK_044_PRESS_A;
+    player->kartProps &= ~PRESS_A;
     // Hacky way to check for START_SPINOUT_TRIGGER
     if ((player->triggers * 8) < 0) {
         func_8008F104(player, player_index);
@@ -3634,7 +3634,7 @@ void player_accelerate_during_start_sequence(Player* player) {
         } else {
             var_v0 = 8;
         }
-        if ((time_delta < var_v0) && ((player->unk_044 & UNK_044_PRESS_A) != UNK_044_PRESS_A)) {
+        if ((time_delta < var_v0) && ((player->kartProps & PRESS_A) != PRESS_A)) {
             player->triggers |= START_BOOST_TRIGGER;
         } else if ((player->topSpeed * 0.9f) <= player->currentSpeed) {
             if ((player->triggers & START_BOOST_TRIGGER) != START_BOOST_TRIGGER) {
@@ -3643,7 +3643,7 @@ void player_accelerate_during_start_sequence(Player* player) {
             }
         }
     }
-    player->unk_044 |= UNK_044_PRESS_A;
+    player->kartProps |= PRESS_A;
     player->unk_098 = (player->currentSpeed * player->currentSpeed) / 25.0f;
 }
 
@@ -3662,7 +3662,7 @@ void player_decelerate_during_start_sequence(Player* player, f32 speedReduction)
         player->triggers &= ~START_SPINOUT_TRIGGER;
     }
     player->triggers &= ~START_BOOST_TRIGGER;
-    player->unk_044 &= ~UNK_044_PRESS_A;
+    player->kartProps &= ~PRESS_A;
     player->unk_098 = (player->currentSpeed * player->currentSpeed) / 25.0f;
 }
 
@@ -3751,7 +3751,7 @@ void player_accelerate_global(Player* player, s32 playerIndex) {
     if (((player->topSpeed * 0.9) <= gPlayerCurrentSpeed[playerIndex]) && (gPlayerCurrentSpeed[playerIndex] <= (player->topSpeed * 1.0))) {
         gPlayerCurrentSpeed[playerIndex] += gKartAccelerationTables[player->characterId][9] * 2.8;
     }
-    player->unk_044 |= UNK_044_PRESS_A;
+    player->kartProps |= PRESS_A;
     if (gPlayerCurrentSpeed[playerIndex] < 0.0f) {
         gPlayerCurrentSpeed[playerIndex] = 0.0f;
     }
@@ -3759,7 +3759,7 @@ void player_accelerate_global(Player* player, s32 playerIndex) {
 }
 
 void player_decelerate_global(Player* player, f32 speedReduction, s32 playerIndex) {
-    player->unk_044 &= ~UNK_044_PRESS_A;
+    player->kartProps &= ~PRESS_A;
     gPlayerCurrentSpeed[playerIndex] -= speedReduction;
     if (gPlayerCurrentSpeed[playerIndex] <= 0.0f) {
         gPlayerCurrentSpeed[playerIndex] = 0.0f;
@@ -3885,30 +3885,30 @@ void func_80033AE0(Player* player, struct Controller* controller, s8 arg2) {
         func_80036CB4(player);
     }
     if ((player->unk_0C0 / DEGREES_CONVERSION_FACTOR) < (-5)) {
-        player->unk_044 |= UNK_044_LEFT_TURN;
-        player->unk_044 &= ~UNK_044_RIGHT_TURN;
+        player->kartProps |= LEFT_TURN;
+        player->kartProps &= ~RIGHT_TURN;
         D_801652C0[arg2]++;
     } else if ((player->unk_0C0 / DEGREES_CONVERSION_FACTOR) > 5) {
-        player->unk_044 |= UNK_044_RIGHT_TURN;
-        player->unk_044 &= ~UNK_044_LEFT_TURN;
+        player->kartProps |= RIGHT_TURN;
+        player->kartProps &= ~LEFT_TURN;
         D_801652C0[arg2]++;
     } else {
-        player->unk_044 &= ~(UNK_044_LEFT_TURN | UNK_044_RIGHT_TURN);
+        player->kartProps &= ~(LEFT_TURN | RIGHT_TURN);
         D_801652C0[arg2] = 0;
     }
     if (((player->effects & HOP_EFFECT) == HOP_EFFECT) || ((player->effects & DRIFTING_EFFECT) == DRIFTING_EFFECT)) {
-        player->unk_044 &= ~(UNK_044_LEFT_TURN | UNK_044_RIGHT_TURN);
+        player->kartProps &= ~(LEFT_TURN | RIGHT_TURN);
     }
     sp2E4 = player->unk_07C;
     temp_v0_3 = get_clamped_stickX_with_deadzone(controller);
-    if (((player->unk_044 & UNK_044_BACK_UP) == UNK_044_BACK_UP) || ((player->unk_044 & UNK_044_MOVE_BACKWARDS) == UNK_044_MOVE_BACKWARDS)) {
+    if (((player->kartProps & BACK_UP) == BACK_UP) || ((player->kartProps & MOVE_BACKWARDS) == MOVE_BACKWARDS)) {
         temp_v0_3 = -temp_v0_3;
     }
     player->unk_07C = (temp_v0_3 << 16) & 0xFFFF0000;
     sp2D0 = sp2E4 - player->unk_07C;
     sp2D0 = sp2D0 >> 16;
     player->unk_0FA = (s16) sp2D0;
-    if (((sp2D0 >= 0x5A) || (sp2D0 < (-0x59))) && (!(player->unk_044 & UNK_044_DRIVING_SPINOUT))) {
+    if (((sp2D0 >= 0x5A) || (sp2D0 < (-0x59))) && (!(player->kartProps & DRIVING_SPINOUT))) {
         if ((((((!(player->effects & DRIFTING_EFFECT)) && (gCCSelection == CC_150)) && (gModeSelection != BATTLE)) &&
               (!(player->effects & MIDAIR_EFFECT))) &&
              (((player->speed / 18.0f) * 216.0f) >= 40.0f)) &&
@@ -3933,7 +3933,7 @@ void func_80033AE0(Player* player, struct Controller* controller, s8 arg2) {
             var_a0 = 0;
         }
         if (((player->speed / 18.0f) * 216.0f) >= 15.0f) {
-            if ((player->unk_044 & UNK_044_RIGHT_TURN) == UNK_044_RIGHT_TURN) {
+            if ((player->kartProps & RIGHT_TURN) == RIGHT_TURN) {
                 if ((sp2D0 < 36) && (sp2D0 >= 0)) {
                     sp2C8 =
                         (gKartTable800E3650[player->characterId] + 1.0f) * (((f32) (var_a0 + 0xF)) * (1.0f + var_f2));
@@ -3943,7 +3943,7 @@ void func_80033AE0(Player* player, struct Controller* controller, s8 arg2) {
                     sp2C8 = (s32) (((f32) (var_a0 + 5)) * (1.0f + var_f2));
                     sp2CC = (s32) (((f32) (var_a0 + 9)) * (1.0f + var_f2));
                 }
-            } else if ((player->unk_044 & UNK_044_LEFT_TURN) == UNK_044_LEFT_TURN) {
+            } else if ((player->kartProps & LEFT_TURN) == LEFT_TURN) {
                 if ((sp2D0 >= (-0x23)) && (sp2D0 <= 0)) {
                     sp2C8 =
                         (gKartTable800E3650[player->characterId] + 1.0f) * (((f32) (var_a0 + 0xF)) * (1.0f + var_f2));
@@ -4299,7 +4299,7 @@ void func_80036DB4(Player* player, Vec3f arg1, Vec3f arg2) {
             ((player->effects & HOP_EFFECT) != HOP_EFFECT)) {
             var_f18 = player->unk_208 + ((-(player->speed / 18.0f) * 216.0f) * 3.0f) + (-player->unk_20C * 10.0f);
             sp20 = player->unk_084 * 3.0f;
-        } else if (!(player->effects & BANANA_NEAR_SPINOUT_EFFECT) && !(player->unk_044 & UNK_044_DRIVING_SPINOUT)) {
+        } else if (!(player->effects & BANANA_NEAR_SPINOUT_EFFECT) && !(player->kartProps & DRIVING_SPINOUT)) {
             thing = player->unk_0FA;
             if (thing > 0) {
                 thing *= -1;
@@ -4360,7 +4360,7 @@ void func_800371F4(Player* player, Vec3f arg1, Vec3f arg2) {
             ((player->effects & HOP_EFFECT) != HOP_EFFECT)) {
             var_f18 = player->unk_208 + ((-(player->speed / 18.0f) * 216.0f) * 3.0f) + (-player->unk_20C * 50.0f);
             sp20 = player->unk_084 * 3.0f;
-        } else if (!(player->effects & BANANA_NEAR_SPINOUT_EFFECT) && !(player->unk_044 & UNK_044_DRIVING_SPINOUT)) {
+        } else if (!(player->effects & BANANA_NEAR_SPINOUT_EFFECT) && !(player->kartProps & DRIVING_SPINOUT)) {
             var_v0 = player->unk_0FA;
             if (var_v0 > 0) {
                 var_v0 *= -1;
@@ -4599,7 +4599,7 @@ void func_80037CFC(Player* player, struct Controller* controller, s8 playerIndex
                 player->effects &= ~AB_SPIN_EFFECT;
             }
         }
-        if ((player->unk_044 & UNK_044_BACK_UP) != UNK_044_BACK_UP) {
+        if ((player->kartProps & BACK_UP) != BACK_UP) {
             if (controller->button & A_BUTTON) {
                 player_accelerate_alternative(player);
                 detect_triple_a_combo_a_pressed(player);
@@ -4623,13 +4623,13 @@ void func_80037CFC(Player* player, struct Controller* controller, s8 playerIndex
             if (((get_clamped_stickY_with_deadzone(controller) < (-0x31)) && (((player->speed / 18.0f) * 216.0f) <= 5.0f)) &&
                 (controller->button & B_BUTTON)) {
                 player->currentSpeed = 140.0f;
-                player->unk_044 |= UNK_044_BACK_UP;
+                player->kartProps |= BACK_UP;
                 player->unk_08C = (player->currentSpeed * player->currentSpeed) / 25.0f;
                 player->unk_20C = 0.0f;
             }
             if ((get_clamped_stickY_with_deadzone(controller) >= -0x1D) || (!(controller->button & B_BUTTON))) {
-                if ((player->unk_044 & UNK_044_BACK_UP) == UNK_044_BACK_UP) {
-                    player->unk_044 &= ~(UNK_044_BACK_UP);
+                if ((player->kartProps & BACK_UP) == BACK_UP) {
+                    player->kartProps &= ~(BACK_UP);
                     player->currentSpeed = 0.0f;
                 }
             }
@@ -4862,7 +4862,7 @@ void func_80038BE4(Player* player, s16 arg1) {
     if (player->currentSpeed >= 250.0f) {
         player->currentSpeed = 250.0f;
     }
-    player->unk_044 |= UNK_044_PRESS_A;
+    player->kartProps |= PRESS_A;
     player->unk_08C = (player->currentSpeed * player->currentSpeed) / 25.0f;
 }
 
@@ -4919,8 +4919,8 @@ void func_80038C6C(Player* player, UNUSED Camera* camera, s8 screenId, s8 player
     newVelocity[0] += ((((((sp114[0] + spA4) + spF0[0])) - (newVelocity[0] * (0.12 * (player->kartFriction)))) / 6000.0) / 1);
     newVelocity[2] += ((((((sp114[2] + sp9C) + spF0[2])) - (newVelocity[2] * (0.12 * (player->kartFriction)))) / 6000.0) / 1);
     newVelocity[1] += ((((((sp114[1] + spA0) + spF0[1])) - (newVelocity[1] * (0.12 * (player->kartFriction)))) / 6000.0) / 1);
-    if ((player->unk_044 & UNK_044_LOSE_GP_RACE) == UNK_044_LOSE_GP_RACE) {
-        player->unk_044 &= ~UNK_044_LOSE_GP_RACE;
+    if ((player->kartProps & LOSE_GP_RACE) == LOSE_GP_RACE) {
+        player->kartProps &= ~LOSE_GP_RACE;
     }
 
     posX = player->pos[0];
@@ -5004,7 +5004,7 @@ void func_80038C6C(Player* player, UNUSED Camera* camera, s8 screenId, s8 player
             player->speed = gKartTopSpeedTable[player->characterId];
         }
     }
-    if ((player->unk_044 & UNK_044_BACK_UP) == UNK_044_BACK_UP) {
+    if ((player->kartProps & BACK_UP) == BACK_UP) {
         if (player->speed > 1.0f) {
             player->velocity[0] *= 1.0f / player->speed;
             player->velocity[1] *= 1.0f / player->speed;

--- a/src/player_controller.c
+++ b/src/player_controller.c
@@ -1802,20 +1802,20 @@ void func_8002C17C(Player* player, s8 playerId) {
 void func_8002C4F8(Player* player, s8 playerIndex) {
     D_801652A0[playerIndex] = func_802AAB4C(player);
     if (player->pos[1] <= D_801652A0[playerIndex]) {
-        player->unk_0DE |= 0x0002;
+        player->unk_0DE |= UNK_0DE_PASS_OOB_OR_FLUID_LEVEL;
     } else {
-        player->unk_0DE &= ~0x0002;
+        player->unk_0DE &= ~UNK_0DE_PASS_OOB_OR_FLUID_LEVEL;
     }
     if (player->boundingBoxSize < (D_801652A0[playerIndex] - player->pos[1])) {
-        player->unk_0DE |= 1;
-        player->unk_0DE &= ~0x0002;
+        player->unk_0DE |= UNK_0DE_UNDER_OOB_OR_FLUID_LEVEL;
+        player->unk_0DE &= ~UNK_0DE_PASS_OOB_OR_FLUID_LEVEL;
     } else {
-        player->unk_0DE &= ~0x0001;
+        player->unk_0DE &= ~UNK_0DE_UNDER_OOB_OR_FLUID_LEVEL;
     }
     if (player->boundingBoxSize < (D_801652A0[playerIndex] - player->pos[1])) {
-        if ((player->unk_0DE & 4) != 4) {
-            player->unk_0DE |= 8;
-            player->unk_0DE |= 4;
+        if ((player->unk_0DE & UNK_0DE_UNDER_FLUID_LEVEL) != UNK_0DE_UNDER_FLUID_LEVEL) {
+            player->unk_0DE |= UNK_0DE_UNDER_OOB_LEVEL;
+            player->unk_0DE |= UNK_0DE_UNDER_FLUID_LEVEL;
             if ((gCurrentCourseId != COURSE_KOOPA_BEACH) && (gCurrentCourseId != COURSE_SKYSCRAPER) &&
                 (gCurrentCourseId != COURSE_RAINBOW_ROAD) && ((player->type & PLAYER_HUMAN) == PLAYER_HUMAN)) {
                 if ((gCurrentCourseId == COURSE_BOWSER_CASTLE) || (gCurrentCourseId == COURSE_BIG_DONUT)) {
@@ -1828,7 +1828,7 @@ void func_8002C4F8(Player* player, s8 playerIndex) {
     }
     if ((gCurrentCourseId == COURSE_KOOPA_BEACH) || (gCurrentCourseId == COURSE_SKYSCRAPER) ||
         (gCurrentCourseId == COURSE_RAINBOW_ROAD)) {
-        player->unk_0DE &= ~0x000C;
+        player->unk_0DE &= ~(UNK_0DE_UNDER_OOB_LEVEL | UNK_0DE_UNDER_FLUID_LEVEL);
     }
     if ((player->boundingBoxSize < (D_801652A0[playerIndex] - player->pos[1])) &&
         (player->collision.surfaceDistance[2] >= 600.0f)) {
@@ -3020,10 +3020,10 @@ f32 func_80030150(Player* player, s8 playerIndex) {
                 var_f0 += -0.25;
             }
         }
-        if ((player->unk_0DE & 1) == 1) {
+        if ((player->unk_0DE & UNK_0DE_UNDER_OOB_OR_FLUID_LEVEL) == UNK_0DE_UNDER_OOB_OR_FLUID_LEVEL) {
             var_f0 += 0.3;
         } else {
-            if ((player->unk_0DE & 2) == 2) {
+            if ((player->unk_0DE & UNK_0DE_PASS_OOB_OR_FLUID_LEVEL) == UNK_0DE_PASS_OOB_OR_FLUID_LEVEL) {
                 var_f0 += 0.15;
             }
             if (((D_801652A0[playerIndex] - player->tyres[BACK_LEFT].baseHeight) >= 3.5) ||
@@ -3962,11 +3962,11 @@ void func_80033AE0(Player* player, struct Controller* controller, s8 arg2) {
             sp2CC = 8;
         }
     }
-    if ((player->unk_0DE & 1) == 1) {
+    if ((player->unk_0DE & UNK_0DE_UNDER_OOB_OR_FLUID_LEVEL) == UNK_0DE_UNDER_OOB_OR_FLUID_LEVEL) {
         sp2C8 *= 1.5;
         sp2CC *= 1.5;
     } else {
-        if ((player->unk_0DE & 2) == 2) {
+        if ((player->unk_0DE & UNK_0DE_PASS_OOB_OR_FLUID_LEVEL) == UNK_0DE_PASS_OOB_OR_FLUID_LEVEL) {
             sp2C8 *= 1.2;
             sp2CC *= 1.2;
         }

--- a/src/player_controller.c
+++ b/src/player_controller.c
@@ -765,10 +765,10 @@ void func_8002934C(Player* player, Camera* camera, s8 screenId, s8 playerId) {
     temp_a0 = (s16) player->unk_0D4[screenId] * sins((u16) temp_a0) + player->unk_0CC[screenId] * coss((u16) temp_a0);
     move_s16_towards(&player->unk_050[screenId], temp_a0, 0.5f);
     var_a0 = player->animFrameSelector[screenId];
-    player->unk_002 = player->unk_002 & (~(4 << (screenId * 4)));
+    player->unk_002 = player->unk_002 & (~(UNK_002_UNKNOWN_0x4 << (screenId * 4)));
     if (var_a0 >= 0x101) {
         var_a0 = 0x201 - var_a0;
-        player->unk_002 |= (4 << (screenId * 4));
+        player->unk_002 |= (UNK_002_UNKNOWN_0x4 << (screenId * 4));
     }
     if (((player->effects & BANANA_SPINOUT_EFFECT) != BANANA_SPINOUT_EFFECT) &&
         ((player->effects & DRIVING_SPINOUT_EFFECT) != DRIVING_SPINOUT_EFFECT) &&
@@ -839,29 +839,29 @@ void func_8002934C(Player* player, Camera* camera, s8 screenId, s8 playerId) {
         ((player->effects & HIT_BY_STAR_EFFECT) == HIT_BY_STAR_EFFECT) || (player->effects & TERRAIN_TUMBLE_EFFECT) ||
         (player->effects & BANANA_SPINOUT_EFFECT) || (player->effects & DRIVING_SPINOUT_EFFECT)) {
 
-        player->unk_002 |= 1 << (screenId * 4);
+        player->unk_002 |= CHANGING_ANIMATION << (screenId * 4);
         D_80165190[screenId][playerId] = 1;
 
         if ((player->effects & BANANA_SPINOUT_EFFECT) || (player->effects & DRIVING_SPINOUT_EFFECT)) {
             if ((player->animFrameSelector[screenId] == gLastAnimFrameSelector[screenId][playerId]) &&
                 (player->animGroupSelector[screenId] == gLastAnimGroupSelector[screenId][playerId])) {
-                player->unk_002 &= ~(1 << (screenId * 4));
+                player->unk_002 &= ~(CHANGING_ANIMATION << (screenId * 4));
                 D_80165190[screenId][playerId] = 1;
             }
         } else if (((player->unk_0A8) >> 8) == D_80165150[screenId][playerId] >> 8) {
-            player->unk_002 &= ~(1 << (screenId * 4));
+            player->unk_002 &= ~(CHANGING_ANIMATION << (screenId * 4));
         }
     } else {
-        player->unk_002 |= 1 << (screenId * 4);
+        player->unk_002 |= CHANGING_ANIMATION << (screenId * 4);
         if (((player->animFrameSelector[screenId] == gLastAnimFrameSelector[screenId][playerId]) &&
              (player->animGroupSelector[screenId] == gLastAnimGroupSelector[screenId][playerId])) &&
             ((D_80165190[screenId][playerId]) == 0)) {
-            player->unk_002 &= ~(1 << (screenId * 4));
+            player->unk_002 &= ~(CHANGING_ANIMATION << (screenId * 4));
         }
     }
     temp_a0_2 = gLastAnimFrameSelector[screenId][playerId] - player->animFrameSelector[screenId];
     if ((temp_a0_2 >= 0x14) || (temp_a0_2 < (-0x13))) {
-        player->unk_002 |= 1 << (screenId * 4);
+        player->unk_002 |= CHANGING_ANIMATION << (screenId * 4);
     }
 }
 

--- a/src/racing/actors.c
+++ b/src/racing/actors.c
@@ -1013,10 +1013,10 @@ void init_kiwano_fruit(void) {
     for (i = 0; i < 4; i++) {
         phi_s1 = &gPlayers[i];
         // temp_v0 = *phi_s1;
-        if ((phi_s1->type & 0x4000) == 0) {
+        if ((phi_s1->type & PLAYER_HUMAN) == 0) {
             continue;
         }
-        if ((phi_s1->type & 0x100) != 0) {
+        if ((phi_s1->type & PLAYER_INVISIBLE_OR_BOMB) != 0) {
             continue;
         }
 
@@ -2091,7 +2091,7 @@ void evaluate_collision_between_player_actor(Player* player, struct Actor* actor
             }
             player->triggers |= HIT_BANANA_TRIGGER;
             owner = &gPlayers[temp_v1];
-            if (owner->type & 0x4000) {
+            if (owner->type & PLAYER_HUMAN) {
                 if (actor->flags & 0xF) {
                     if (temp_lo != temp_v1) {
                         func_800C90F4(temp_v1, (owner->characterId * 0x10) + SOUND_ARG_LOAD(0x29, 0x00, 0x80, 0x06));
@@ -2121,7 +2121,7 @@ void evaluate_collision_between_player_actor(Player* player, struct Actor* actor
             player->triggers |= LOW_TUMBLE_TRIGGER;
             func_800C98B8(player->pos, player->velocity, SOUND_ARG_LOAD(0x19, 0x01, 0x80, 0x10));
             owner = &gPlayers[temp_v1];
-            if ((owner->type & 0x4000) && (temp_lo != temp_v1)) {
+            if ((owner->type & PLAYER_HUMAN) && (temp_lo != temp_v1)) {
                 func_800C90F4(temp_v1, (owner->characterId * 0x10) + SOUND_ARG_LOAD(0x29, 0x00, 0x80, 0x06));
             }
             destroy_destructable_actor(actor);
@@ -2140,7 +2140,7 @@ void evaluate_collision_between_player_actor(Player* player, struct Actor* actor
                 func_800C98B8(player->pos, player->velocity, SOUND_ARG_LOAD(0x19, 0x01, 0x80, 0x10));
             }
             owner = &gPlayers[temp_v1];
-            if ((owner->type & 0x4000) && (temp_lo != temp_v1)) {
+            if ((owner->type & PLAYER_HUMAN) && (temp_lo != temp_v1)) {
                 func_800C90F4(temp_v1, (owner->characterId * 0x10) + SOUND_ARG_LOAD(0x29, 0x00, 0x80, 0x06));
             }
             if (temp_lo == actor->unk_04) {
@@ -2165,7 +2165,7 @@ void evaluate_collision_between_player_actor(Player* player, struct Actor* actor
                 func_800C98B8(player->pos, player->velocity, SOUND_ARG_LOAD(0x19, 0x01, 0x80, 0x10));
             }
             owner = &gPlayers[temp_v1];
-            if ((owner->type & 0x4000) && (temp_lo != temp_v1)) {
+            if ((owner->type & PLAYER_HUMAN) && (temp_lo != temp_v1)) {
                 func_800C90F4(temp_v1, (owner->characterId * 0x10) + SOUND_ARG_LOAD(0x29, 0x00, 0x80, 0x06));
             }
             destroy_destructable_actor(actor);
@@ -2223,7 +2223,7 @@ void evaluate_collision_between_player_actor(Player* player, struct Actor* actor
             }
             player->triggers |= VERTICAL_TUMBLE_TRIGGER;
             owner = &gPlayers[temp_v1];
-            if (owner->type & 0x4000) {
+            if (owner->type & PLAYER_HUMAN) {
                 if (actor->flags & 0xF) {
                     if (temp_lo != temp_v1) {
                         func_800C90F4(temp_v1, (owner->characterId * 0x10) + SOUND_ARG_LOAD(0x29, 0x00, 0x80, 0x06));

--- a/src/racing/actors_extended.c
+++ b/src/racing/actors_extended.c
@@ -100,7 +100,7 @@ void destroy_banana_in_banana_bunch(struct BananaActor* banana) {
 
     func_802B0464(banana->youngerIndex);
     func_802B04E8(banana, banana->elderIndex);
-    if ((gPlayers[banana->playerId].type & 0x4000) != 0) {
+    if ((gPlayers[banana->playerId].type & PLAYER_HUMAN) != 0) {
         func_800C9060(banana->playerId, SOUND_ARG_LOAD(0x19, 0x01, 0x90, 0x53));
     }
     banana->flags = -0x8000;
@@ -294,7 +294,7 @@ void update_actor_banana_bunch(struct BananaBunchParent* banana_bunch) {
             if (someCount == 0) {
                 destroy_actor((struct Actor*) banana_bunch);
                 owner->triggers &= ~DRAG_ITEM_EFFECT;
-            } else if ((owner->type & 0x4000) != 0) {
+            } else if ((owner->type & PLAYER_HUMAN) != 0) {
                 controller = &gControllers[banana_bunch->playerId];
                 if ((controller->buttonPressed & Z_TRIG) != 0) {
                     controller->buttonPressed &= ~Z_TRIG;

--- a/src/render_player.c
+++ b/src/render_player.c
@@ -896,10 +896,10 @@ void func_8002276C(void) {
                     break;
                 case TIME_TRIALS: /* switch 1 */
                     func_80022A98(gPlayerOne, 0);
-                    if ((gPlayerTwo->type & 0x100) == 0x100) {
+                    if ((gPlayerTwo->type & PLAYER_INVISIBLE_OR_BOMB) == PLAYER_INVISIBLE_OR_BOMB) {
                         func_80022A98(gPlayerTwo, 1);
                     }
-                    if ((gPlayerThree->type & 0x100) == 0x100) {
+                    if ((gPlayerThree->type & PLAYER_INVISIBLE_OR_BOMB) == PLAYER_INVISIBLE_OR_BOMB) {
                         func_80022A98(gPlayerThree, 2);
                     }
                     break;

--- a/src/render_player.c
+++ b/src/render_player.c
@@ -654,16 +654,16 @@ void func_80021B0C(void) {
         func_8006E7CC(gPlayerEight, 7, 0);
     }
     if (gGamestate == ENDING) {
-        if (gPlayerOne->unk_044 & UNK_044_UNUSED_0x2000) {
+        if (gPlayerOne->kartProps & UNUSED_0x2000) {
             render_player_shadow_credits(gPlayerOne, 0, 0);
         }
-        if (gPlayerTwo->unk_044 & UNK_044_UNUSED_0x2000) {
+        if (gPlayerTwo->kartProps & UNUSED_0x2000) {
             render_player_shadow_credits(gPlayerTwo, 1, 0);
         }
-        if (gPlayerThree->unk_044 & UNK_044_UNUSED_0x2000) {
+        if (gPlayerThree->kartProps & UNUSED_0x2000) {
             render_player_shadow_credits(gPlayerThree, 2, 0);
         }
-        if (gPlayerFour->unk_044 & UNK_044_UNUSED_0x2000) {
+        if (gPlayerFour->kartProps & UNUSED_0x2000) {
             render_player_shadow_credits(gPlayerFour, 3, 0);
         }
     }
@@ -1424,7 +1424,7 @@ void render_kart(Player* player, s8 playerId, s8 arg2, s8 flipOffset) {
     s16 temp_v1;
     s16 thing;
 
-    if (player->unk_044 & UNK_044_UNUSED_0x2000) {
+    if (player->kartProps & UNUSED_0x2000) {
         sp14C[0] = 0;
         sp14C[1] = player->unk_048[arg2];
         sp14C[2] = 0;
@@ -1782,7 +1782,7 @@ void update_wheel_palette(Player* player, s8 playerId, s8 screenId, s8 arg3) {
     if (((player->effects & EARLY_START_SPINOUT_EFFECT) == EARLY_START_SPINOUT_EFFECT) && ((player->type & PLAYER_START_SEQUENCE) == 0)) {
         if (((player->effects & BANANA_SPINOUT_EFFECT) != BANANA_SPINOUT_EFFECT) && ((player->effects & DRIVING_SPINOUT_EFFECT) != DRIVING_SPINOUT_EFFECT) &&
             ((player->effects & LIGHTNING_STRIKE_EFFECT) != LIGHTNING_STRIKE_EFFECT) && ((player->effects & UNKNOWN_EFFECT_0x80000) != UNKNOWN_EFFECT_0x80000) &&
-            ((player->effects & UNKNOWN_EFFECT_0x800000) != UNKNOWN_EFFECT_0x800000) && ((player->unk_044 & UNK_044_UNUSED_0x800) == 0)) {
+            ((player->effects & UNKNOWN_EFFECT_0x800000) != UNKNOWN_EFFECT_0x800000) && ((player->kartProps & UNUSED_0x800) == 0)) {
 
             if (frameId <= 20) {
                 load_player_data_non_blocking(player,
@@ -1811,7 +1811,7 @@ void update_wheel_palette(Player* player, s8 playerId, s8 screenId, s8 arg3) {
     } else {
         if (((player->effects & BANANA_SPINOUT_EFFECT) != BANANA_SPINOUT_EFFECT) && ((player->effects & DRIVING_SPINOUT_EFFECT) != DRIVING_SPINOUT_EFFECT) &&
             ((player->effects & UNKNOWN_EFFECT_0x80000) != UNKNOWN_EFFECT_0x80000) && ((player->effects & UNKNOWN_EFFECT_0x800000) != UNKNOWN_EFFECT_0x800000) &&
-            ((player->effects & LIGHTNING_STRIKE_EFFECT) != LIGHTNING_STRIKE_EFFECT) && ((player->unk_044 & UNK_044_UNUSED_0x800) == 0)) {
+            ((player->effects & LIGHTNING_STRIKE_EFFECT) != LIGHTNING_STRIKE_EFFECT) && ((player->kartProps & UNUSED_0x800) == 0)) {
 
             if (frameId <= 20) {
                 load_player_data_non_blocking(player,

--- a/src/render_player.c
+++ b/src/render_player.c
@@ -1185,23 +1185,23 @@ void func_800235AC(Player* player, s8 playerIndex) {
         return;
     }
 
-    if (((player->lakitu_props & FRIGID_EFFECT) == FRIGID_EFFECT) &&
-        ((player->lakitu_props & LAKITU_FIZZLE) == LAKITU_FIZZLE)) {
+    if (((player->lakituProps & FRIGID_EFFECT) == FRIGID_EFFECT) &&
+        ((player->lakituProps & LAKITU_FIZZLE) == LAKITU_FIZZLE)) {
         change_player_color_effect_rgb(player, playerIndex, 0x646464, 0.5f);
         change_player_color_effect_cmy(player, playerIndex, 0xFF0000, 0.1f);
         return;
     }
-    if ((player->lakitu_props & LAKITU_FIZZLE) == LAKITU_FIZZLE) {
+    if ((player->lakituProps & LAKITU_FIZZLE) == LAKITU_FIZZLE) {
         change_player_color_effect_rgb(player, playerIndex, COLOR_BLACK, 1.0f);
         change_player_color_effect_cmy(player, playerIndex, 0, 1.0f);
         return;
     }
-    if ((player->lakitu_props & FRIGID_EFFECT) == FRIGID_EFFECT) {
+    if ((player->lakituProps & FRIGID_EFFECT) == FRIGID_EFFECT) {
         change_player_color_effect_rgb(player, playerIndex, 0x646464, 0.5f);
         change_player_color_effect_cmy(player, playerIndex, 0xFF0000, 0.1f);
         return;
     }
-    if ((player->lakitu_props & THAWING_EFFECT) == THAWING_EFFECT) {
+    if ((player->lakituProps & THAWING_EFFECT) == THAWING_EFFECT) {
         change_player_color_effect_rgb(player, playerIndex, COLOR_BLACK, 0.1f);
         change_player_color_effect_cmy(player, playerIndex, 0, 0.1f);
         return;
@@ -1265,7 +1265,7 @@ void func_800235AC(Player* player, s8 playerIndex) {
             return;
         }
         render_light_environment_on_player(player, playerIndex);
-        if ((player->lakitu_props & LAKITU_LAVA) == LAKITU_LAVA) {
+        if ((player->lakituProps & LAKITU_LAVA) == LAKITU_LAVA) {
             change_player_color_effect_rgb(player, playerIndex, COLOR_BLACK, 0.3f);
             change_player_color_effect_cmy(player, playerIndex, 0xF0F0F0, 0.3f);
         }
@@ -1279,7 +1279,7 @@ void func_80023BF0(Player* player, s8 playerId, s8 screenId, s8 arg3) {
     } else {
         func_80022E84(player, playerId, screenId, arg3);
     }
-    if ((player->lakitu_props & HELD_BY_LAKITU) == HELD_BY_LAKITU) {
+    if ((player->lakituProps & HELD_BY_LAKITU) == HELD_BY_LAKITU) {
         func_80022D60(player, playerId, screenId, arg3);
     }
 }
@@ -1308,7 +1308,7 @@ void render_player_shadow(Player* player, s8 playerId, s8 screenId) {
         ((player->effects & UNKNOWN_EFFECT_0x80000) == UNKNOWN_EFFECT_0x80000) ||
         ((player->effects & UNKNOWN_EFFECT_0x800000) == UNKNOWN_EFFECT_0x800000) ||
         ((player->effects & HIT_BY_GREEN_SHELL_EFFECT) == HIT_BY_GREEN_SHELL_EFFECT) ||
-        ((player->lakitu_props & HELD_BY_LAKITU) == HELD_BY_LAKITU) ||
+        ((player->lakituProps & HELD_BY_LAKITU) == HELD_BY_LAKITU) ||
         ((player->effects & HIT_BY_STAR_EFFECT) == HIT_BY_STAR_EFFECT) ||
         ((player->effects & TERRAIN_TUMBLE_EFFECT) == TERRAIN_TUMBLE_EFFECT) ||
         ((player->effects & MIDAIR_EFFECT) == MIDAIR_EFFECT)) {
@@ -1509,7 +1509,7 @@ void render_kart(Player* player, s8 playerId, s8 arg2, s8 flipOffset) {
                              AA_EN | Z_CMP | Z_UPD | IM_RD | CVG_DST_WRAP | ZMODE_XLU | CVG_X_ALPHA | FORCE_BL |
                                  GBL_c2(G_BL_CLR_IN, G_BL_A_IN, G_BL_CLR_MEM, G_BL_1MA));
         }
-    } else if (((player->lakitu_props & LAKITU_FIZZLE) == LAKITU_FIZZLE) || (player->triggers & BECOME_BOMB_EFFECT) ||
+    } else if (((player->lakituProps & LAKITU_FIZZLE) == LAKITU_FIZZLE) || (player->triggers & BECOME_BOMB_EFFECT) ||
                (player->triggers & LOSE_BATTLE_EFFECT)) {
         gSPMatrix(gDisplayListHead++, VIRTUAL_TO_PHYSICAL(&gGfxPool->mtxKart[playerId + (arg2 * 8)]),
                   G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
@@ -1743,7 +1743,7 @@ void render_player(Player* player, s8 playerId, s8 screenId) {
     }
     osRecvMesg(&gDmaMesgQueue, (OSMesg*) &sp34, OS_MESG_BLOCK);
     if ((temp_t1 == (player->unk_002 & temp_t1)) && (player->surfaceType == ICE) &&
-        ((player->lakitu_props & LAKITU_RETRIEVAL) != LAKITU_RETRIEVAL) &&
+        ((player->lakituProps & LAKITU_RETRIEVAL) != LAKITU_RETRIEVAL) &&
         (player->collision.surfaceDistance[2] <= 30.0f)) {
         render_player_ice_reflection(player, playerId, screenId, flipOffset);
     }

--- a/src/render_player.c
+++ b/src/render_player.c
@@ -1184,22 +1184,22 @@ void func_800235AC(Player* player, s8 playerIndex) {
         return;
     }
 
-    if (((player->unk_0CA & 0x10) == 0x10) && ((player->unk_0CA & 4) == 4)) {
+    if (((player->unk_0CA & UNK_0CA_FRIGID_EFFECT) == UNK_0CA_FRIGID_EFFECT) && ((player->unk_0CA & UNK_0CA_LAKITU_FIZZLE) == UNK_0CA_LAKITU_FIZZLE)) {
         change_player_color_effect_rgb(player, playerIndex, 0x646464, 0.5f);
         change_player_color_effect_cmy(player, playerIndex, 0xFF0000, 0.1f);
         return;
     }
-    if ((player->unk_0CA & 4) == 4) {
+    if ((player->unk_0CA & UNK_0CA_LAKITU_FIZZLE) == UNK_0CA_LAKITU_FIZZLE) {
         change_player_color_effect_rgb(player, playerIndex, COLOR_BLACK, 1.0f);
         change_player_color_effect_cmy(player, playerIndex, 0, 1.0f);
         return;
     }
-    if ((player->unk_0CA & 0x10) == 0x10) {
+    if ((player->unk_0CA & UNK_0CA_FRIGID_EFFECT) == UNK_0CA_FRIGID_EFFECT) {
         change_player_color_effect_rgb(player, playerIndex, 0x646464, 0.5f);
         change_player_color_effect_cmy(player, playerIndex, 0xFF0000, 0.1f);
         return;
     }
-    if ((player->unk_0CA & 0x20) == 0x20) {
+    if ((player->unk_0CA & UNK_0CA_THAWING_EFFECT) == UNK_0CA_THAWING_EFFECT) {
         change_player_color_effect_rgb(player, playerIndex, COLOR_BLACK, 0.1f);
         change_player_color_effect_cmy(player, playerIndex, 0, 0.1f);
         return;
@@ -1263,7 +1263,7 @@ void func_800235AC(Player* player, s8 playerIndex) {
             return;
         }
         render_light_environment_on_player(player, playerIndex);
-        if ((player->unk_0CA & 0x1000) == 0x1000) {
+        if ((player->unk_0CA & UNK_0CA_LAKITU_LAVA) == UNK_0CA_LAKITU_LAVA) {
             change_player_color_effect_rgb(player, playerIndex, COLOR_BLACK, 0.3f);
             change_player_color_effect_cmy(player, playerIndex, 0xF0F0F0, 0.3f);
         }
@@ -1276,7 +1276,7 @@ void func_80023BF0(Player* player, s8 playerId, s8 screenId, s8 arg3) {
     } else {
         func_80022E84(player, playerId, screenId, arg3);
     }
-    if ((player->unk_0CA & 2) == 2) {
+    if ((player->unk_0CA & UNK_0CA_HELD_BY_LAKITU) == UNK_0CA_HELD_BY_LAKITU) {
         func_80022D60(player, playerId, screenId, arg3);
     }
 }
@@ -1303,7 +1303,7 @@ void render_player_shadow(Player* player, s8 playerId, s8 screenId) {
     if (((player->effects & EXPLOSION_CRASH_EFFECT) == EXPLOSION_CRASH_EFFECT) ||
         ((player->effects & HIT_BY_GREEN_SHELL_EFFECT) == HIT_BY_GREEN_SHELL_EFFECT) || ((player->effects & UNKNOWN_EFFECT_0x80000) == UNKNOWN_EFFECT_0x80000) ||
         ((player->effects & UNKNOWN_EFFECT_0x800000) == UNKNOWN_EFFECT_0x800000) || ((player->effects & HIT_BY_GREEN_SHELL_EFFECT) == HIT_BY_GREEN_SHELL_EFFECT) ||
-        ((player->unk_0CA & 2) == 2) || ((player->effects & HIT_BY_STAR_EFFECT) == HIT_BY_STAR_EFFECT) ||
+        ((player->unk_0CA & UNK_0CA_HELD_BY_LAKITU) == UNK_0CA_HELD_BY_LAKITU) || ((player->effects & HIT_BY_STAR_EFFECT) == HIT_BY_STAR_EFFECT) ||
         ((player->effects & TERRAIN_TUMBLE_EFFECT) == TERRAIN_TUMBLE_EFFECT) || ((player->effects & MIDAIR_EFFECT) == MIDAIR_EFFECT)) {
 
         var_f2 = (f32) (1.0 - ((f64) player->collision.surfaceDistance[2] * 0.02));
@@ -1502,7 +1502,7 @@ void render_kart(Player* player, s8 playerId, s8 arg2, s8 flipOffset) {
                              AA_EN | Z_CMP | Z_UPD | IM_RD | CVG_DST_WRAP | ZMODE_XLU | CVG_X_ALPHA | FORCE_BL |
                                  GBL_c2(G_BL_CLR_IN, G_BL_A_IN, G_BL_CLR_MEM, G_BL_1MA));
         }
-    } else if (((player->unk_0CA & 4) == 4) || (player->triggers & BECOME_BOMB_EFFECT) ||
+    } else if (((player->unk_0CA & UNK_0CA_LAKITU_FIZZLE) == UNK_0CA_LAKITU_FIZZLE) || (player->triggers & BECOME_BOMB_EFFECT) ||
                (player->triggers & LOSE_BATTLE_EFFECT)) {
         gSPMatrix(gDisplayListHead++, VIRTUAL_TO_PHYSICAL(&gGfxPool->mtxKart[playerId + (arg2 * 8)]),
                   G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
@@ -1735,7 +1735,7 @@ void render_player(Player* player, s8 playerId, s8 screenId) {
         render_ghost(player, playerId, screenId, flipOffset);
     }
     osRecvMesg(&gDmaMesgQueue, (OSMesg*) &sp34, OS_MESG_BLOCK);
-    if ((temp_t1 == (player->unk_002 & temp_t1)) && (player->surfaceType == ICE) && ((player->unk_0CA & 1) != 1) &&
+    if ((temp_t1 == (player->unk_002 & temp_t1)) && (player->surfaceType == ICE) && ((player->unk_0CA & UNK_0CA_LAKITU_RETRIEVAL) != UNK_0CA_LAKITU_RETRIEVAL) &&
         (player->collision.surfaceDistance[2] <= 30.0f)) {
         render_player_ice_reflection(player, playerId, screenId, flipOffset);
     }

--- a/src/render_player.c
+++ b/src/render_player.c
@@ -1184,22 +1184,22 @@ void func_800235AC(Player* player, s8 playerIndex) {
         return;
     }
 
-    if (((player->unk_0CA & UNK_0CA_FRIGID_EFFECT) == UNK_0CA_FRIGID_EFFECT) && ((player->unk_0CA & UNK_0CA_LAKITU_FIZZLE) == UNK_0CA_LAKITU_FIZZLE)) {
+    if (((player->lakitu_props & FRIGID_EFFECT) == FRIGID_EFFECT) && ((player->lakitu_props & LAKITU_FIZZLE) == LAKITU_FIZZLE)) {
         change_player_color_effect_rgb(player, playerIndex, 0x646464, 0.5f);
         change_player_color_effect_cmy(player, playerIndex, 0xFF0000, 0.1f);
         return;
     }
-    if ((player->unk_0CA & UNK_0CA_LAKITU_FIZZLE) == UNK_0CA_LAKITU_FIZZLE) {
+    if ((player->lakitu_props & LAKITU_FIZZLE) == LAKITU_FIZZLE) {
         change_player_color_effect_rgb(player, playerIndex, COLOR_BLACK, 1.0f);
         change_player_color_effect_cmy(player, playerIndex, 0, 1.0f);
         return;
     }
-    if ((player->unk_0CA & UNK_0CA_FRIGID_EFFECT) == UNK_0CA_FRIGID_EFFECT) {
+    if ((player->lakitu_props & FRIGID_EFFECT) == FRIGID_EFFECT) {
         change_player_color_effect_rgb(player, playerIndex, 0x646464, 0.5f);
         change_player_color_effect_cmy(player, playerIndex, 0xFF0000, 0.1f);
         return;
     }
-    if ((player->unk_0CA & UNK_0CA_THAWING_EFFECT) == UNK_0CA_THAWING_EFFECT) {
+    if ((player->lakitu_props & THAWING_EFFECT) == THAWING_EFFECT) {
         change_player_color_effect_rgb(player, playerIndex, COLOR_BLACK, 0.1f);
         change_player_color_effect_cmy(player, playerIndex, 0, 0.1f);
         return;
@@ -1263,7 +1263,7 @@ void func_800235AC(Player* player, s8 playerIndex) {
             return;
         }
         render_light_environment_on_player(player, playerIndex);
-        if ((player->unk_0CA & UNK_0CA_LAKITU_LAVA) == UNK_0CA_LAKITU_LAVA) {
+        if ((player->lakitu_props & LAKITU_LAVA) == LAKITU_LAVA) {
             change_player_color_effect_rgb(player, playerIndex, COLOR_BLACK, 0.3f);
             change_player_color_effect_cmy(player, playerIndex, 0xF0F0F0, 0.3f);
         }
@@ -1276,7 +1276,7 @@ void func_80023BF0(Player* player, s8 playerId, s8 screenId, s8 arg3) {
     } else {
         func_80022E84(player, playerId, screenId, arg3);
     }
-    if ((player->unk_0CA & UNK_0CA_HELD_BY_LAKITU) == UNK_0CA_HELD_BY_LAKITU) {
+    if ((player->lakitu_props & HELD_BY_LAKITU) == HELD_BY_LAKITU) {
         func_80022D60(player, playerId, screenId, arg3);
     }
 }
@@ -1303,7 +1303,7 @@ void render_player_shadow(Player* player, s8 playerId, s8 screenId) {
     if (((player->effects & EXPLOSION_CRASH_EFFECT) == EXPLOSION_CRASH_EFFECT) ||
         ((player->effects & HIT_BY_GREEN_SHELL_EFFECT) == HIT_BY_GREEN_SHELL_EFFECT) || ((player->effects & UNKNOWN_EFFECT_0x80000) == UNKNOWN_EFFECT_0x80000) ||
         ((player->effects & UNKNOWN_EFFECT_0x800000) == UNKNOWN_EFFECT_0x800000) || ((player->effects & HIT_BY_GREEN_SHELL_EFFECT) == HIT_BY_GREEN_SHELL_EFFECT) ||
-        ((player->unk_0CA & UNK_0CA_HELD_BY_LAKITU) == UNK_0CA_HELD_BY_LAKITU) || ((player->effects & HIT_BY_STAR_EFFECT) == HIT_BY_STAR_EFFECT) ||
+        ((player->lakitu_props & HELD_BY_LAKITU) == HELD_BY_LAKITU) || ((player->effects & HIT_BY_STAR_EFFECT) == HIT_BY_STAR_EFFECT) ||
         ((player->effects & TERRAIN_TUMBLE_EFFECT) == TERRAIN_TUMBLE_EFFECT) || ((player->effects & MIDAIR_EFFECT) == MIDAIR_EFFECT)) {
 
         var_f2 = (f32) (1.0 - ((f64) player->collision.surfaceDistance[2] * 0.02));
@@ -1502,7 +1502,7 @@ void render_kart(Player* player, s8 playerId, s8 arg2, s8 flipOffset) {
                              AA_EN | Z_CMP | Z_UPD | IM_RD | CVG_DST_WRAP | ZMODE_XLU | CVG_X_ALPHA | FORCE_BL |
                                  GBL_c2(G_BL_CLR_IN, G_BL_A_IN, G_BL_CLR_MEM, G_BL_1MA));
         }
-    } else if (((player->unk_0CA & UNK_0CA_LAKITU_FIZZLE) == UNK_0CA_LAKITU_FIZZLE) || (player->triggers & BECOME_BOMB_EFFECT) ||
+    } else if (((player->lakitu_props & LAKITU_FIZZLE) == LAKITU_FIZZLE) || (player->triggers & BECOME_BOMB_EFFECT) ||
                (player->triggers & LOSE_BATTLE_EFFECT)) {
         gSPMatrix(gDisplayListHead++, VIRTUAL_TO_PHYSICAL(&gGfxPool->mtxKart[playerId + (arg2 * 8)]),
                   G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
@@ -1735,7 +1735,7 @@ void render_player(Player* player, s8 playerId, s8 screenId) {
         render_ghost(player, playerId, screenId, flipOffset);
     }
     osRecvMesg(&gDmaMesgQueue, (OSMesg*) &sp34, OS_MESG_BLOCK);
-    if ((temp_t1 == (player->unk_002 & temp_t1)) && (player->surfaceType == ICE) && ((player->unk_0CA & UNK_0CA_LAKITU_RETRIEVAL) != UNK_0CA_LAKITU_RETRIEVAL) &&
+    if ((temp_t1 == (player->unk_002 & temp_t1)) && (player->surfaceType == ICE) && ((player->lakitu_props & LAKITU_RETRIEVAL) != LAKITU_RETRIEVAL) &&
         (player->collision.surfaceDistance[2] <= 30.0f)) {
         render_player_ice_reflection(player, playerId, screenId, flipOffset);
     }

--- a/src/render_player.c
+++ b/src/render_player.c
@@ -654,16 +654,16 @@ void func_80021B0C(void) {
         func_8006E7CC(gPlayerEight, 7, 0);
     }
     if (gGamestate == ENDING) {
-        if (gPlayerOne->unk_044 & 0x2000) {
+        if (gPlayerOne->unk_044 & UNK_044_UNUSED_0x2000) {
             render_player_shadow_credits(gPlayerOne, 0, 0);
         }
-        if (gPlayerTwo->unk_044 & 0x2000) {
+        if (gPlayerTwo->unk_044 & UNK_044_UNUSED_0x2000) {
             render_player_shadow_credits(gPlayerTwo, 1, 0);
         }
-        if (gPlayerThree->unk_044 & 0x2000) {
+        if (gPlayerThree->unk_044 & UNK_044_UNUSED_0x2000) {
             render_player_shadow_credits(gPlayerThree, 2, 0);
         }
-        if (gPlayerFour->unk_044 & 0x2000) {
+        if (gPlayerFour->unk_044 & UNK_044_UNUSED_0x2000) {
             render_player_shadow_credits(gPlayerFour, 3, 0);
         }
     }
@@ -1424,7 +1424,7 @@ void render_kart(Player* player, s8 playerId, s8 arg2, s8 flipOffset) {
     s16 temp_v1;
     s16 thing;
 
-    if (player->unk_044 & 0x2000) {
+    if (player->unk_044 & UNK_044_UNUSED_0x2000) {
         sp14C[0] = 0;
         sp14C[1] = player->unk_048[arg2];
         sp14C[2] = 0;
@@ -1782,7 +1782,7 @@ void update_wheel_palette(Player* player, s8 playerId, s8 screenId, s8 arg3) {
     if (((player->effects & EARLY_START_SPINOUT_EFFECT) == EARLY_START_SPINOUT_EFFECT) && ((player->type & PLAYER_START_SEQUENCE) == 0)) {
         if (((player->effects & BANANA_SPINOUT_EFFECT) != BANANA_SPINOUT_EFFECT) && ((player->effects & DRIVING_SPINOUT_EFFECT) != DRIVING_SPINOUT_EFFECT) &&
             ((player->effects & LIGHTNING_STRIKE_EFFECT) != LIGHTNING_STRIKE_EFFECT) && ((player->effects & UNKNOWN_EFFECT_0x80000) != UNKNOWN_EFFECT_0x80000) &&
-            ((player->effects & UNKNOWN_EFFECT_0x800000) != UNKNOWN_EFFECT_0x800000) && ((player->unk_044 & 0x800) == 0)) {
+            ((player->effects & UNKNOWN_EFFECT_0x800000) != UNKNOWN_EFFECT_0x800000) && ((player->unk_044 & UNK_044_UNUSED_0x800) == 0)) {
 
             if (frameId <= 20) {
                 load_player_data_non_blocking(player,
@@ -1811,7 +1811,7 @@ void update_wheel_palette(Player* player, s8 playerId, s8 screenId, s8 arg3) {
     } else {
         if (((player->effects & BANANA_SPINOUT_EFFECT) != BANANA_SPINOUT_EFFECT) && ((player->effects & DRIVING_SPINOUT_EFFECT) != DRIVING_SPINOUT_EFFECT) &&
             ((player->effects & UNKNOWN_EFFECT_0x80000) != UNKNOWN_EFFECT_0x80000) && ((player->effects & UNKNOWN_EFFECT_0x800000) != UNKNOWN_EFFECT_0x800000) &&
-            ((player->effects & LIGHTNING_STRIKE_EFFECT) != LIGHTNING_STRIKE_EFFECT) && ((player->unk_044 & 0x800) == 0)) {
+            ((player->effects & LIGHTNING_STRIKE_EFFECT) != LIGHTNING_STRIKE_EFFECT) && ((player->unk_044 & UNK_044_UNUSED_0x800) == 0)) {
 
             if (frameId <= 20) {
                 load_player_data_non_blocking(player,

--- a/src/render_player.c
+++ b/src/render_player.c
@@ -79,14 +79,14 @@ void func_8001F9E4(Player* player, Camera* camera, s8 screenId) {
     get_player_index_for_player(player);
     func_8001F980(&sp30, &sp2C);
 
-    player->unk_002 &= ~(2 << (screenId * 4));
-    player->unk_002 &= ~(8 << (screenId * 4));
+    player->unk_002 &= ~(UNK_002_UNKNOWN_0x2 << (screenId * 4));
+    player->unk_002 &= ~(SIDE_OF_KART << (screenId * 4));
 
     if (check_player_camera_collision(player, camera, (f32) (D_80165578 + sp30), (f32) (D_8016557A + sp2C)) == 1) {
-        player->unk_002 |= 2 << (screenId * 4);
+        player->unk_002 |= UNK_002_UNKNOWN_0x2 << (screenId * 4);
     }
     if (check_player_camera_collision(player, camera, (f32) D_80165580, (f32) D_80165582) == 1) {
-        player->unk_002 |= 8 << (screenId * 4);
+        player->unk_002 |= SIDE_OF_KART << (screenId * 4);
     }
 }
 
@@ -181,7 +181,7 @@ void init_render_player(Player* player, Camera* camera, s8 playerId, s8 screenId
 
     if ((player->type & PLAYER_EXISTS) == PLAYER_EXISTS) {
         func_8001F9E4(player, camera, screenId);
-        temp_v0 = 2 << (screenId << 2);
+        temp_v0 = UNK_002_UNKNOWN_0x2 << (screenId << 2);
         if (temp_v0 == (player->unk_002 & temp_v0)) {
             if (!(player->type & PLAYER_START_SEQUENCE)) {
                 func_8002934C(player, camera, screenId, playerId);
@@ -193,7 +193,7 @@ void init_render_player(Player* player, Camera* camera, s8 playerId, s8 screenId
             }
         }
         func_8001F980(&sp4C, &sp48);
-        temp_v0_2 = 1 << (screenId << 2);
+        temp_v0_2 = CHANGING_ANIMATION << (screenId << 2);
         if ((temp_v0 == (player->unk_002 & temp_v0)) && (temp_v0_2 == (player->unk_002 & temp_v0_2))) {
             if ((check_player_camera_collision(player, camera, D_80165570 + sp4C, D_80165572 + sp48) == 1) & 0xFFFF) {
                 gPlayersToRenderPlayerId[gPlayersToRenderCount] = (s16) playerId;
@@ -424,7 +424,7 @@ void load_kart_texture_and_render_kart_particle_on_screen_four(void) {
 void try_rendering_player(Player* player, s8 playerId, s8 arg2) {
 
     if (((player->type & PLAYER_EXISTS) == PLAYER_EXISTS) && ((player->type & PLAYER_UNKNOWN_0x40) == 0)) {
-        if ((player->unk_002 & 2 << (arg2 * 4)) == 2 << (arg2 * 4)) {
+        if ((player->unk_002 & UNK_002_UNKNOWN_0x2 << (arg2 * 4)) == UNK_002_UNKNOWN_0x2 << (arg2 * 4)) {
             render_player(player, playerId, arg2);
         }
     }
@@ -1673,7 +1673,7 @@ void render_player_ice_reflection(Player* player, s8 playerId, s8 screenId, s8 f
     sp9C[0] = player->pos[0];
     sp9C[1] = player->unk_074 + (4.0f * player->size);
     sp9C[2] = player->pos[2];
-    if (!(player->unk_002 & (4 << (screenId * 4)))) {
+    if (!(player->unk_002 & (UNK_002_UNKNOWN_0x4 << (screenId * 4)))) {
         flipOffset = 8;
     } else {
         flipOffset = 0;
@@ -1712,13 +1712,13 @@ void render_player(Player* player, s8 playerId, s8 screenId) {
     OSMesg* sp34;
 
     update_wheel_palette(player, playerId, screenId, D_801651D0[screenId][playerId]);
-    if (!(player->unk_002 & (4 << (screenId * 4)))) {
+    if (!(player->unk_002 & (UNK_002_UNKNOWN_0x4 << (screenId * 4)))) {
         flipOffset = 0;
     } else {
         flipOffset = 8;
     }
     func_80023BF0(player, playerId, screenId, flipOffset);
-    temp_t1 = 8 << (screenId * 4);
+    temp_t1 = SIDE_OF_KART << (screenId * 4);
     if ((temp_t1 == (player->unk_002 & temp_t1)) && (player->collision.surfaceDistance[2] <= 50.0f) &&
         (player->surfaceType != ICE)) {
         if ((player->effects & BOO_EFFECT) == BOO_EFFECT) {

--- a/src/render_player.c
+++ b/src/render_player.c
@@ -956,7 +956,8 @@ void func_80022A98(Player* player, s8 playerIndex) {
     if ((player->type & PLAYER_EXISTS) == PLAYER_EXISTS) {
         func_80026A48(player, playerIndex);
         func_800235AC(player, playerIndex);
-        if (((player->effects & SQUISH_EFFECT) == SQUISH_EFFECT) || ((player->effects & POST_SQUISH_EFFECT) == POST_SQUISH_EFFECT)) {
+        if (((player->effects & SQUISH_EFFECT) == SQUISH_EFFECT) ||
+            ((player->effects & POST_SQUISH_EFFECT) == POST_SQUISH_EFFECT)) {
             if ((player->effects & SQUISH_EFFECT) == SQUISH_EFFECT) {
                 func_80022B50(player, playerIndex);
             }
@@ -1184,7 +1185,8 @@ void func_800235AC(Player* player, s8 playerIndex) {
         return;
     }
 
-    if (((player->lakitu_props & FRIGID_EFFECT) == FRIGID_EFFECT) && ((player->lakitu_props & LAKITU_FIZZLE) == LAKITU_FIZZLE)) {
+    if (((player->lakitu_props & FRIGID_EFFECT) == FRIGID_EFFECT) &&
+        ((player->lakitu_props & LAKITU_FIZZLE) == LAKITU_FIZZLE)) {
         change_player_color_effect_rgb(player, playerIndex, 0x646464, 0.5f);
         change_player_color_effect_cmy(player, playerIndex, 0xFF0000, 0.1f);
         return;
@@ -1271,7 +1273,8 @@ void func_800235AC(Player* player, s8 playerIndex) {
 }
 
 void func_80023BF0(Player* player, s8 playerId, s8 screenId, s8 arg3) {
-    if (((player->effects & SQUISH_EFFECT) == SQUISH_EFFECT) || ((player->effects & POST_SQUISH_EFFECT) == POST_SQUISH_EFFECT)) {
+    if (((player->effects & SQUISH_EFFECT) == SQUISH_EFFECT) ||
+        ((player->effects & POST_SQUISH_EFFECT) == POST_SQUISH_EFFECT)) {
         func_80022CA8(player, playerId, screenId, arg3);
     } else {
         func_80022E84(player, playerId, screenId, arg3);
@@ -1301,10 +1304,14 @@ void render_player_shadow(Player* player, s8 playerId, s8 screenId) {
     spAC = -sins(temp_t9 << 7) * 2;
 
     if (((player->effects & EXPLOSION_CRASH_EFFECT) == EXPLOSION_CRASH_EFFECT) ||
-        ((player->effects & HIT_BY_GREEN_SHELL_EFFECT) == HIT_BY_GREEN_SHELL_EFFECT) || ((player->effects & UNKNOWN_EFFECT_0x80000) == UNKNOWN_EFFECT_0x80000) ||
-        ((player->effects & UNKNOWN_EFFECT_0x800000) == UNKNOWN_EFFECT_0x800000) || ((player->effects & HIT_BY_GREEN_SHELL_EFFECT) == HIT_BY_GREEN_SHELL_EFFECT) ||
-        ((player->lakitu_props & HELD_BY_LAKITU) == HELD_BY_LAKITU) || ((player->effects & HIT_BY_STAR_EFFECT) == HIT_BY_STAR_EFFECT) ||
-        ((player->effects & TERRAIN_TUMBLE_EFFECT) == TERRAIN_TUMBLE_EFFECT) || ((player->effects & MIDAIR_EFFECT) == MIDAIR_EFFECT)) {
+        ((player->effects & HIT_BY_GREEN_SHELL_EFFECT) == HIT_BY_GREEN_SHELL_EFFECT) ||
+        ((player->effects & UNKNOWN_EFFECT_0x80000) == UNKNOWN_EFFECT_0x80000) ||
+        ((player->effects & UNKNOWN_EFFECT_0x800000) == UNKNOWN_EFFECT_0x800000) ||
+        ((player->effects & HIT_BY_GREEN_SHELL_EFFECT) == HIT_BY_GREEN_SHELL_EFFECT) ||
+        ((player->lakitu_props & HELD_BY_LAKITU) == HELD_BY_LAKITU) ||
+        ((player->effects & HIT_BY_STAR_EFFECT) == HIT_BY_STAR_EFFECT) ||
+        ((player->effects & TERRAIN_TUMBLE_EFFECT) == TERRAIN_TUMBLE_EFFECT) ||
+        ((player->effects & MIDAIR_EFFECT) == MIDAIR_EFFECT)) {
 
         var_f2 = (f32) (1.0 - ((f64) player->collision.surfaceDistance[2] * 0.02));
         if (var_f2 < 0.0f) {
@@ -1735,7 +1742,8 @@ void render_player(Player* player, s8 playerId, s8 screenId) {
         render_ghost(player, playerId, screenId, flipOffset);
     }
     osRecvMesg(&gDmaMesgQueue, (OSMesg*) &sp34, OS_MESG_BLOCK);
-    if ((temp_t1 == (player->unk_002 & temp_t1)) && (player->surfaceType == ICE) && ((player->lakitu_props & LAKITU_RETRIEVAL) != LAKITU_RETRIEVAL) &&
+    if ((temp_t1 == (player->unk_002 & temp_t1)) && (player->surfaceType == ICE) &&
+        ((player->lakitu_props & LAKITU_RETRIEVAL) != LAKITU_RETRIEVAL) &&
         (player->collision.surfaceDistance[2] <= 30.0f)) {
         render_player_ice_reflection(player, playerId, screenId, flipOffset);
     }
@@ -1747,7 +1755,8 @@ void render_player(Player* player, s8 playerId, s8 screenId) {
 void func_80026A48(Player* player, s8 playerIndex) {
     f32 temp_f0;
 
-    if (((player->effects & EARLY_START_SPINOUT_EFFECT) == EARLY_START_SPINOUT_EFFECT) && ((player->type & PLAYER_START_SEQUENCE) == 0)) {
+    if (((player->effects & EARLY_START_SPINOUT_EFFECT) == EARLY_START_SPINOUT_EFFECT) &&
+        ((player->type & PLAYER_START_SEQUENCE) == 0)) {
         player->tyreSpeed += D_800DDE74[8];
         if (player->tyreSpeed >= 0x400) {
             player->tyreSpeed = 0;
@@ -1779,10 +1788,14 @@ void update_wheel_palette(Player* player, s8 playerId, s8 screenId, s8 arg3) {
     s16 temp_t2 = player->tyreSpeed;
     s16 temp_num = 0x40; // setting this as a variable gets rid of regalloc
 
-    if (((player->effects & EARLY_START_SPINOUT_EFFECT) == EARLY_START_SPINOUT_EFFECT) && ((player->type & PLAYER_START_SEQUENCE) == 0)) {
-        if (((player->effects & BANANA_SPINOUT_EFFECT) != BANANA_SPINOUT_EFFECT) && ((player->effects & DRIVING_SPINOUT_EFFECT) != DRIVING_SPINOUT_EFFECT) &&
-            ((player->effects & LIGHTNING_STRIKE_EFFECT) != LIGHTNING_STRIKE_EFFECT) && ((player->effects & UNKNOWN_EFFECT_0x80000) != UNKNOWN_EFFECT_0x80000) &&
-            ((player->effects & UNKNOWN_EFFECT_0x800000) != UNKNOWN_EFFECT_0x800000) && ((player->kartProps & UNUSED_0x800) == 0)) {
+    if (((player->effects & EARLY_START_SPINOUT_EFFECT) == EARLY_START_SPINOUT_EFFECT) &&
+        ((player->type & PLAYER_START_SEQUENCE) == 0)) {
+        if (((player->effects & BANANA_SPINOUT_EFFECT) != BANANA_SPINOUT_EFFECT) &&
+            ((player->effects & DRIVING_SPINOUT_EFFECT) != DRIVING_SPINOUT_EFFECT) &&
+            ((player->effects & LIGHTNING_STRIKE_EFFECT) != LIGHTNING_STRIKE_EFFECT) &&
+            ((player->effects & UNKNOWN_EFFECT_0x80000) != UNKNOWN_EFFECT_0x80000) &&
+            ((player->effects & UNKNOWN_EFFECT_0x800000) != UNKNOWN_EFFECT_0x800000) &&
+            ((player->kartProps & UNUSED_0x800) == 0)) {
 
             if (frameId <= 20) {
                 load_player_data_non_blocking(player,
@@ -1809,9 +1822,12 @@ void update_wheel_palette(Player* player, s8 playerId, s8 screenId, s8 arg3) {
             }
         }
     } else {
-        if (((player->effects & BANANA_SPINOUT_EFFECT) != BANANA_SPINOUT_EFFECT) && ((player->effects & DRIVING_SPINOUT_EFFECT) != DRIVING_SPINOUT_EFFECT) &&
-            ((player->effects & UNKNOWN_EFFECT_0x80000) != UNKNOWN_EFFECT_0x80000) && ((player->effects & UNKNOWN_EFFECT_0x800000) != UNKNOWN_EFFECT_0x800000) &&
-            ((player->effects & LIGHTNING_STRIKE_EFFECT) != LIGHTNING_STRIKE_EFFECT) && ((player->kartProps & UNUSED_0x800) == 0)) {
+        if (((player->effects & BANANA_SPINOUT_EFFECT) != BANANA_SPINOUT_EFFECT) &&
+            ((player->effects & DRIVING_SPINOUT_EFFECT) != DRIVING_SPINOUT_EFFECT) &&
+            ((player->effects & UNKNOWN_EFFECT_0x80000) != UNKNOWN_EFFECT_0x80000) &&
+            ((player->effects & UNKNOWN_EFFECT_0x800000) != UNKNOWN_EFFECT_0x800000) &&
+            ((player->effects & LIGHTNING_STRIKE_EFFECT) != LIGHTNING_STRIKE_EFFECT) &&
+            ((player->kartProps & UNUSED_0x800) == 0)) {
 
             if (frameId <= 20) {
                 load_player_data_non_blocking(player,

--- a/src/replays.c
+++ b/src/replays.c
@@ -454,7 +454,8 @@ void save_player_replay(void) {
     u32 prevInputs;
     /* Input file is too long or picked up by lakitu or Out of bounds
     Not sure if there is any way to be considered out of bounds without lakitu getting called */
-    if (((sPlayerInputIdx >= 0x1000) || ((gPlayerOne->lakitu_props & HELD_BY_LAKITU) != 0)) || ((gPlayerOne->lakitu_props & LAKITU_SCENE) != 0)) {
+    if (((sPlayerInputIdx >= 0x1000) || ((gPlayerOne->lakitu_props & HELD_BY_LAKITU) != 0)) ||
+        ((gPlayerOne->lakitu_props & LAKITU_SCENE) != 0)) {
         gPostTimeTrialReplayCannotSave = 1;
         return;
     }

--- a/src/replays.c
+++ b/src/replays.c
@@ -454,7 +454,7 @@ void save_player_replay(void) {
     u32 prevInputs;
     /* Input file is too long or picked up by lakitu or Out of bounds
     Not sure if there is any way to be considered out of bounds without lakitu getting called */
-    if (((sPlayerInputIdx >= 0x1000) || ((gPlayerOne->unk_0CA & UNK_0CA_HELD_BY_LAKITU) != 0)) || ((gPlayerOne->unk_0CA & UNK_0CA_LAKITU_SCENE) != 0)) {
+    if (((sPlayerInputIdx >= 0x1000) || ((gPlayerOne->lakitu_props & HELD_BY_LAKITU) != 0)) || ((gPlayerOne->lakitu_props & LAKITU_SCENE) != 0)) {
         gPostTimeTrialReplayCannotSave = 1;
         return;
     }

--- a/src/replays.c
+++ b/src/replays.c
@@ -454,7 +454,7 @@ void save_player_replay(void) {
     u32 prevInputs;
     /* Input file is too long or picked up by lakitu or Out of bounds
     Not sure if there is any way to be considered out of bounds without lakitu getting called */
-    if (((sPlayerInputIdx >= 0x1000) || ((gPlayerOne->unk_0CA & 2) != 0)) || ((gPlayerOne->unk_0CA & 8) != 0)) {
+    if (((sPlayerInputIdx >= 0x1000) || ((gPlayerOne->unk_0CA & UNK_0CA_HELD_BY_LAKITU) != 0)) || ((gPlayerOne->unk_0CA & UNK_0CA_LAKITU_SCENE) != 0)) {
         gPostTimeTrialReplayCannotSave = 1;
         return;
     }

--- a/src/replays.c
+++ b/src/replays.c
@@ -556,7 +556,7 @@ void func_80005B18(void) {
                 sReplayGhostBufferSize = D_80162D86;
                 D_80162DDC = 1;
             }
-            if ((gPlayerOne->type & 0x800) == 0x800) {
+            if ((gPlayerOne->type & PLAYER_CINEMATIC_MODE) == PLAYER_CINEMATIC_MODE) {
                 func_80005AE8(gPlayerTwo);
                 func_80005AE8(gPlayerThree);
             } else {

--- a/src/replays.c
+++ b/src/replays.c
@@ -454,8 +454,8 @@ void save_player_replay(void) {
     u32 prevInputs;
     /* Input file is too long or picked up by lakitu or Out of bounds
     Not sure if there is any way to be considered out of bounds without lakitu getting called */
-    if (((sPlayerInputIdx >= 0x1000) || ((gPlayerOne->lakitu_props & HELD_BY_LAKITU) != 0)) ||
-        ((gPlayerOne->lakitu_props & LAKITU_SCENE) != 0)) {
+    if (((sPlayerInputIdx >= 0x1000) || ((gPlayerOne->lakituProps & HELD_BY_LAKITU) != 0)) ||
+        ((gPlayerOne->lakituProps & LAKITU_SCENE) != 0)) {
         gPostTimeTrialReplayCannotSave = 1;
         return;
     }

--- a/src/spawn_players.c
+++ b/src/spawn_players.c
@@ -145,7 +145,7 @@ void spawn_player(Player* player, s8 playerIndex, f32 startingRow, f32 startingC
     player->unk_074 = 0.0f;
     player->type = playerType;
     player->lakitu_props = 0;
-    player->unk_0DE = 0;
+    player->oobProps = 0;
     player->unk_10C = 0;
     player->unk_0E2 = 0;
     player->unk_0E8 = 0.0f;
@@ -187,7 +187,7 @@ void spawn_player(Player* player, s8 playerIndex, f32 startingRow, f32 startingC
     player->unk_0C8 = 0;
     player->lakitu_props = 0;
     player->boostTimer = 0;
-    player->unk_0DE = 0;
+    player->oobProps = 0;
     player->unk_0E0 = 0;
     player->unk_0E2 = 0;
     player->unk_10C = 0;

--- a/src/spawn_players.c
+++ b/src/spawn_players.c
@@ -144,7 +144,7 @@ void spawn_player(Player* player, s8 playerIndex, f32 startingRow, f32 startingC
     player->speed = 0.0f;
     player->unk_074 = 0.0f;
     player->type = playerType;
-    player->unk_0CA = 0;
+    player->lakitu_props = 0;
     player->unk_0DE = 0;
     player->unk_10C = 0;
     player->unk_0E2 = 0;
@@ -185,7 +185,7 @@ void spawn_player(Player* player, s8 playerIndex, f32 startingRow, f32 startingC
     player->unk_0C0 = 0;
     player->unk_0C2 = 0;
     player->unk_0C8 = 0;
-    player->unk_0CA = 0;
+    player->lakitu_props = 0;
     player->boostTimer = 0;
     player->unk_0DE = 0;
     player->unk_0E0 = 0;

--- a/src/spawn_players.c
+++ b/src/spawn_players.c
@@ -81,7 +81,7 @@ void spawn_player(Player* player, s8 playerIndex, f32 startingRow, f32 startingC
     player->type = PLAYER_INACTIVE;
     player->unk_08C = 0;
     player->characterId = characterId;
-    player->unk_0B6 = 0;
+    player->kart_graphics = 0;
     player->kartFriction = gKartFrictionTable[player->characterId];
     player->boundingBoxSize = gKartBoundingBoxSizeTable[player->characterId];
     player->kartGravity = gKartGravityTable[player->characterId];

--- a/src/spawn_players.c
+++ b/src/spawn_players.c
@@ -81,7 +81,7 @@ void spawn_player(Player* player, s8 playerIndex, f32 startingRow, f32 startingC
     player->type = PLAYER_INACTIVE;
     player->unk_08C = 0;
     player->characterId = characterId;
-    player->kart_graphics = 0;
+    player->kartGraphics = 0;
     player->kartFriction = gKartFrictionTable[player->characterId];
     player->boundingBoxSize = gKartBoundingBoxSizeTable[player->characterId];
     player->kartGravity = gKartGravityTable[player->characterId];
@@ -144,7 +144,7 @@ void spawn_player(Player* player, s8 playerIndex, f32 startingRow, f32 startingC
     player->speed = 0.0f;
     player->unk_074 = 0.0f;
     player->type = playerType;
-    player->lakitu_props = 0;
+    player->lakituProps = 0;
     player->oobProps = 0;
     player->unk_10C = 0;
     player->unk_0E2 = 0;
@@ -185,7 +185,7 @@ void spawn_player(Player* player, s8 playerIndex, f32 startingRow, f32 startingC
     player->unk_0C0 = 0;
     player->unk_0C2 = 0;
     player->unk_0C8 = 0;
-    player->lakitu_props = 0;
+    player->lakituProps = 0;
     player->boostTimer = 0;
     player->oobProps = 0;
     player->unk_0E0 = 0;

--- a/src/spawn_players.c
+++ b/src/spawn_players.c
@@ -154,7 +154,7 @@ void spawn_player(Player* player, s8 playerIndex, f32 startingRow, f32 startingC
     player->currentSpeed = 0.0f;
     player->unk_20C = 0.0f;
     player->unk_DAC = 0.0f;
-    player->unk_044 = 0;
+    player->kartProps = 0;
     player->unk_046 = 0;
     player->triggers = 0;
     player->alpha = ALPHA_MAX;

--- a/src/update_objects.c
+++ b/src/update_objects.c
@@ -2978,14 +2978,14 @@ void func_800791F0(s32 objectIndex, s32 playerId) {
     if ((gObjectList[objectIndex].unk_0D8 != 3) && (gObjectList[objectIndex].unk_0D8 != 7)) {
         func_800722CC(objectIndex, 1);
         if (gCurrentCourseId == COURSE_SHERBET_LAND) {
-            player->lakitu_props &= ~FRIGID_EFFECT;
+            player->lakituProps &= ~FRIGID_EFFECT;
         }
     } else {
         // ?????
     }
     if (gCurrentCourseId == COURSE_SHERBET_LAND) {
         func_800722CC(objectIndex, 0x00000010);
-        player->lakitu_props &= ~THAWING_EFFECT;
+        player->lakituProps &= ~THAWING_EFFECT;
     }
     func_800C9018(playerId, SOUND_ARG_LOAD(0x01, 0x00, 0xFA, 0x28));
 }
@@ -3127,9 +3127,9 @@ void func_800797AC(s32 playerId) {
 
     objectIndex = gIndexLakituList[playerId];
     player = &gPlayerOne[playerId];
-    if ((gCurrentCourseId == COURSE_SHERBET_LAND) && (player->lakitu_props & LAKITU_RETRIEVAL)) {
+    if ((gCurrentCourseId == COURSE_SHERBET_LAND) && (player->lakituProps & LAKITU_RETRIEVAL)) {
         init_object(objectIndex, 7);
-        player->lakitu_props |= FRIGID_EFFECT;
+        player->lakituProps |= FRIGID_EFFECT;
     } else {
         init_object(objectIndex, 3);
     }
@@ -3144,7 +3144,7 @@ void func_80079860(s32 playerId) {
     player = &gPlayerOne[playerId];
     if ((func_80072354(objectIndex, 1) != 0) &&
         (((func_802ABDF4(player->collision.meshIndexZX) != 0) && (player->collision.surfaceDistance[2] <= 3.0f)) ||
-         (player->lakitu_props & LAKITU_RETRIEVAL) ||
+         (player->lakituProps & LAKITU_RETRIEVAL) ||
          ((player->surfaceType == OUT_OF_BOUNDS) && !(player->effects & MIDAIR_EFFECT)))) {
         func_80090778(player);
         func_800797AC(playerId);
@@ -3152,7 +3152,7 @@ void func_80079860(s32 playerId) {
 }
 
 void func_8007993C(s32 objectIndex, Player* player) {
-    if (player->lakitu_props & LAKITU_FIZZLE) {
+    if (player->lakituProps & LAKITU_FIZZLE) {
         func_800722A4(objectIndex, 2);
         gObjectList[objectIndex].primAlpha = player->alpha;
         return;
@@ -3229,7 +3229,7 @@ void update_object_lakitu_fishing(s32 objectIndex, s32 playerId) {
             func_80073654(objectIndex);
             break;
         case 3:
-            if (!(player->lakitu_props & HELD_BY_LAKITU)) {
+            if (!(player->lakituProps & HELD_BY_LAKITU)) {
                 func_80086EAC(objectIndex, 0, 3);
                 func_80073654(objectIndex);
             }
@@ -3264,7 +3264,7 @@ void update_object_lakitu_fishing2(s32 objectIndex, s32 playerId) {
         case 2: /* switch 1 */
             set_object_flag_status_true(objectIndex, 0x00000010);
             func_800736E0(objectIndex);
-            player->lakitu_props |= FROZEN_EFFECT;
+            player->lakituProps |= FROZEN_EFFECT;
             object_next_state(objectIndex);
             break;
         case 3: /* switch 1 */
@@ -3284,11 +3284,11 @@ void update_object_lakitu_fishing2(s32 objectIndex, s32 playerId) {
             func_80073654(objectIndex);
             break;
         case 3:
-            if ((player->surfaceType == ICE) && !(player->lakitu_props & LAKITU_RETRIEVAL) &&
+            if ((player->surfaceType == ICE) && !(player->lakituProps & LAKITU_RETRIEVAL) &&
                 ((f64) player->collision.surfaceDistance[2] <= 30.0)) {
                 func_800722A4(objectIndex, 8);
             }
-            if (!(player->lakitu_props & HELD_BY_LAKITU)) {
+            if (!(player->lakituProps & HELD_BY_LAKITU)) {
                 func_80086EAC(objectIndex, 0, 3);
                 func_80073654(objectIndex);
             }
@@ -3297,7 +3297,7 @@ void update_object_lakitu_fishing2(s32 objectIndex, s32 playerId) {
             func_8007375C(objectIndex, 0x0000001E);
             break;
         case 5:
-            player->lakitu_props &= ~FROZEN_EFFECT;
+            player->lakituProps &= ~FROZEN_EFFECT;
             func_800722A4(objectIndex, 0x00000010);
             func_800722A4(objectIndex, 0x00000020);
             func_800722CC(objectIndex, 4);
@@ -3308,8 +3308,8 @@ void update_object_lakitu_fishing2(s32 objectIndex, s32 playerId) {
         case 6:
             if (func_8007375C(objectIndex, 0x000000A0) != 0) {
                 func_800722CC(objectIndex, 0x00000010);
-                player->lakitu_props &= ~FRIGID_EFFECT;
-                player->lakitu_props |= THAWING_EFFECT;
+                player->lakituProps &= ~FRIGID_EFFECT;
+                player->lakituProps |= THAWING_EFFECT;
             }
             break;
         case 7:
@@ -3318,7 +3318,7 @@ void update_object_lakitu_fishing2(s32 objectIndex, s32 playerId) {
         case 8:
             func_80073720(objectIndex);
             func_80072428(objectIndex);
-            player->lakitu_props &= ~THAWING_EFFECT;
+            player->lakituProps &= ~THAWING_EFFECT;
             func_800722CC(objectIndex, 1);
             func_800C9018((u8) playerId, SOUND_ARG_LOAD(0x01, 0x00, 0xFA, 0x28));
             break;

--- a/src/update_objects.c
+++ b/src/update_objects.c
@@ -3144,7 +3144,8 @@ void func_80079860(s32 playerId) {
     player = &gPlayerOne[playerId];
     if ((func_80072354(objectIndex, 1) != 0) &&
         (((func_802ABDF4(player->collision.meshIndexZX) != 0) && (player->collision.surfaceDistance[2] <= 3.0f)) ||
-         (player->lakitu_props & LAKITU_RETRIEVAL) || ((player->surfaceType == OUT_OF_BOUNDS) && !(player->effects & MIDAIR_EFFECT)))) {
+         (player->lakitu_props & LAKITU_RETRIEVAL) ||
+         ((player->surfaceType == OUT_OF_BOUNDS) && !(player->effects & MIDAIR_EFFECT)))) {
         func_80090778(player);
         func_800797AC(playerId);
     }

--- a/src/update_objects.c
+++ b/src/update_objects.c
@@ -5977,11 +5977,11 @@ void func_80080B28(s32 objectIndex, s32 playerId) {
             temp_f0 = func_80088F54(objectIndex, temp_s0);
             if ((temp_f0 <= 9.0) && !(temp_s0->effects & SQUISH_EFFECT) &&
                 (has_collided_horizontally_with_player(objectIndex, temp_s0) != 0)) {
-                if ((temp_s0->type & PLAYER_EXISTS) && !(temp_s0->type & 0x100)) {
+                if ((temp_s0->type & PLAYER_EXISTS) && !(temp_s0->type & PLAYER_INVISIBLE_OR_BOMB)) {
                     if (!(temp_s0->effects & STAR_EFFECT)) {
                         func_80089474(objectIndex, playerId, 1.4f, 1.1f, SOUND_ARG_LOAD(0x19, 0x00, 0xA0, 0x4C));
                     } else if (func_80072354(objectIndex, 0x00000040) != 0) {
-                        if (temp_s0->type & 0x1000) {
+                        if (temp_s0->type & PLAYER_CPU) {
                             func_800C98B8(temp_s0->pos, temp_s0->velocity, SOUND_ARG_LOAD(0x19, 0x01, 0xA2, 0x4A));
                         } else {
                             func_800C9060((u8) playerId, SOUND_ARG_LOAD(0x19, 0x01, 0xA2, 0x4A));
@@ -5997,7 +5997,7 @@ void func_80080B28(s32 objectIndex, s32 playerId) {
             } else if ((temp_f0 <= 17.5) && (func_80072320(objectIndex, 1) != 0) &&
                        (is_within_horizontal_distance_of_player(objectIndex, temp_s0, (temp_s0->speed * 0.5) + 7.0) !=
                         0)) {
-                if ((temp_s0->type & PLAYER_EXISTS) && !(temp_s0->type & 0x100)) {
+                if ((temp_s0->type & PLAYER_EXISTS) && !(temp_s0->type & PLAYER_INVISIBLE_OR_BOMB)) {
                     if (is_obj_flag_status_active(objectIndex, 0x04000000) != 0) {
                         func_80072180();
                     }
@@ -6380,7 +6380,7 @@ void func_80081D34(s32 objectIndex) {
     for (playerIndex = 0; playerIndex < D_8018D158; playerIndex++, player++, var_s4++) {
         if ((is_obj_flag_status_active(objectIndex, 0x00000200) != 0) && !(player->effects & BOO_EFFECT) &&
             (has_collided_with_player(objectIndex, player) != 0)) {
-            if ((player->type & PLAYER_EXISTS) && !(player->type & 0x100)) {
+            if ((player->type & PLAYER_EXISTS) && !(player->type & PLAYER_INVISIBLE_OR_BOMB)) {
                 var_s5 = 1;
                 object = &gObjectList[objectIndex];
                 if (is_obj_flag_status_active(objectIndex, 0x04000000) != 0) {

--- a/src/update_objects.c
+++ b/src/update_objects.c
@@ -126,7 +126,7 @@ s32 find_unused_obj_index(s32* arg0) {
         }
     } while ((gObjectList[temp_v1].unk_0CA != 0) && (temp_v0 != OBJECT_LIST_SIZE));
 
-    gObjectList[temp_v1].unk_0CA = UNK_0CA_LAKITU_RETRIEVAL;
+    gObjectList[temp_v1].unk_0CA = 1;
 
     *arg0 = temp_v1;
     objectListSize = temp_v1;
@@ -2978,14 +2978,14 @@ void func_800791F0(s32 objectIndex, s32 playerId) {
     if ((gObjectList[objectIndex].unk_0D8 != 3) && (gObjectList[objectIndex].unk_0D8 != 7)) {
         func_800722CC(objectIndex, 1);
         if (gCurrentCourseId == COURSE_SHERBET_LAND) {
-            player->unk_0CA &= ~UNK_0CA_FRIGID_EFFECT;
+            player->lakitu_props &= ~FRIGID_EFFECT;
         }
     } else {
         // ?????
     }
     if (gCurrentCourseId == COURSE_SHERBET_LAND) {
         func_800722CC(objectIndex, 0x00000010);
-        player->unk_0CA &= ~UNK_0CA_THAWING_EFFECT;
+        player->lakitu_props &= ~THAWING_EFFECT;
     }
     func_800C9018(playerId, SOUND_ARG_LOAD(0x01, 0x00, 0xFA, 0x28));
 }
@@ -3127,9 +3127,9 @@ void func_800797AC(s32 playerId) {
 
     objectIndex = gIndexLakituList[playerId];
     player = &gPlayerOne[playerId];
-    if ((gCurrentCourseId == COURSE_SHERBET_LAND) && (player->unk_0CA & UNK_0CA_LAKITU_RETRIEVAL)) {
+    if ((gCurrentCourseId == COURSE_SHERBET_LAND) && (player->lakitu_props & LAKITU_RETRIEVAL)) {
         init_object(objectIndex, 7);
-        player->unk_0CA |= UNK_0CA_FRIGID_EFFECT;
+        player->lakitu_props |= FRIGID_EFFECT;
     } else {
         init_object(objectIndex, 3);
     }
@@ -3144,14 +3144,14 @@ void func_80079860(s32 playerId) {
     player = &gPlayerOne[playerId];
     if ((func_80072354(objectIndex, 1) != 0) &&
         (((func_802ABDF4(player->collision.meshIndexZX) != 0) && (player->collision.surfaceDistance[2] <= 3.0f)) ||
-         (player->unk_0CA & UNK_0CA_LAKITU_RETRIEVAL) || ((player->surfaceType == OUT_OF_BOUNDS) && !(player->effects & MIDAIR_EFFECT)))) {
+         (player->lakitu_props & LAKITU_RETRIEVAL) || ((player->surfaceType == OUT_OF_BOUNDS) && !(player->effects & MIDAIR_EFFECT)))) {
         func_80090778(player);
         func_800797AC(playerId);
     }
 }
 
 void func_8007993C(s32 objectIndex, Player* player) {
-    if (player->unk_0CA & UNK_0CA_LAKITU_FIZZLE) {
+    if (player->lakitu_props & LAKITU_FIZZLE) {
         func_800722A4(objectIndex, 2);
         gObjectList[objectIndex].primAlpha = player->alpha;
         return;
@@ -3228,7 +3228,7 @@ void update_object_lakitu_fishing(s32 objectIndex, s32 playerId) {
             func_80073654(objectIndex);
             break;
         case 3:
-            if (!(player->unk_0CA & UNK_0CA_HELD_BY_LAKITU)) {
+            if (!(player->lakitu_props & HELD_BY_LAKITU)) {
                 func_80086EAC(objectIndex, 0, 3);
                 func_80073654(objectIndex);
             }
@@ -3263,7 +3263,7 @@ void update_object_lakitu_fishing2(s32 objectIndex, s32 playerId) {
         case 2: /* switch 1 */
             set_object_flag_status_true(objectIndex, 0x00000010);
             func_800736E0(objectIndex);
-            player->unk_0CA |= UNK_0CA_FROZEN_EFFECT;
+            player->lakitu_props |= FROZEN_EFFECT;
             object_next_state(objectIndex);
             break;
         case 3: /* switch 1 */
@@ -3283,11 +3283,11 @@ void update_object_lakitu_fishing2(s32 objectIndex, s32 playerId) {
             func_80073654(objectIndex);
             break;
         case 3:
-            if ((player->surfaceType == ICE) && !(player->unk_0CA & UNK_0CA_LAKITU_RETRIEVAL) &&
+            if ((player->surfaceType == ICE) && !(player->lakitu_props & LAKITU_RETRIEVAL) &&
                 ((f64) player->collision.surfaceDistance[2] <= 30.0)) {
                 func_800722A4(objectIndex, 8);
             }
-            if (!(player->unk_0CA & UNK_0CA_HELD_BY_LAKITU)) {
+            if (!(player->lakitu_props & HELD_BY_LAKITU)) {
                 func_80086EAC(objectIndex, 0, 3);
                 func_80073654(objectIndex);
             }
@@ -3296,7 +3296,7 @@ void update_object_lakitu_fishing2(s32 objectIndex, s32 playerId) {
             func_8007375C(objectIndex, 0x0000001E);
             break;
         case 5:
-            player->unk_0CA &= ~UNK_0CA_FROZEN_EFFECT;
+            player->lakitu_props &= ~FROZEN_EFFECT;
             func_800722A4(objectIndex, 0x00000010);
             func_800722A4(objectIndex, 0x00000020);
             func_800722CC(objectIndex, 4);
@@ -3307,8 +3307,8 @@ void update_object_lakitu_fishing2(s32 objectIndex, s32 playerId) {
         case 6:
             if (func_8007375C(objectIndex, 0x000000A0) != 0) {
                 func_800722CC(objectIndex, 0x00000010);
-                player->unk_0CA &= ~UNK_0CA_FRIGID_EFFECT;
-                player->unk_0CA |= UNK_0CA_THAWING_EFFECT;
+                player->lakitu_props &= ~FRIGID_EFFECT;
+                player->lakitu_props |= THAWING_EFFECT;
             }
             break;
         case 7:
@@ -3317,7 +3317,7 @@ void update_object_lakitu_fishing2(s32 objectIndex, s32 playerId) {
         case 8:
             func_80073720(objectIndex);
             func_80072428(objectIndex);
-            player->unk_0CA &= ~UNK_0CA_THAWING_EFFECT;
+            player->lakitu_props &= ~THAWING_EFFECT;
             func_800722CC(objectIndex, 1);
             func_800C9018((u8) playerId, SOUND_ARG_LOAD(0x01, 0x00, 0xFA, 0x28));
             break;

--- a/src/update_objects.c
+++ b/src/update_objects.c
@@ -126,7 +126,7 @@ s32 find_unused_obj_index(s32* arg0) {
         }
     } while ((gObjectList[temp_v1].unk_0CA != 0) && (temp_v0 != OBJECT_LIST_SIZE));
 
-    gObjectList[temp_v1].unk_0CA = 1;
+    gObjectList[temp_v1].unk_0CA = UNK_0CA_LAKITU_RETRIEVAL;
 
     *arg0 = temp_v1;
     objectListSize = temp_v1;
@@ -2978,14 +2978,14 @@ void func_800791F0(s32 objectIndex, s32 playerId) {
     if ((gObjectList[objectIndex].unk_0D8 != 3) && (gObjectList[objectIndex].unk_0D8 != 7)) {
         func_800722CC(objectIndex, 1);
         if (gCurrentCourseId == COURSE_SHERBET_LAND) {
-            player->unk_0CA &= 0xFFEF;
+            player->unk_0CA &= ~UNK_0CA_FRIGID_EFFECT;
         }
     } else {
         // ?????
     }
     if (gCurrentCourseId == COURSE_SHERBET_LAND) {
         func_800722CC(objectIndex, 0x00000010);
-        player->unk_0CA &= 0xFFDF;
+        player->unk_0CA &= ~UNK_0CA_THAWING_EFFECT;
     }
     func_800C9018(playerId, SOUND_ARG_LOAD(0x01, 0x00, 0xFA, 0x28));
 }
@@ -3127,9 +3127,9 @@ void func_800797AC(s32 playerId) {
 
     objectIndex = gIndexLakituList[playerId];
     player = &gPlayerOne[playerId];
-    if ((gCurrentCourseId == COURSE_SHERBET_LAND) && (player->unk_0CA & 1)) {
+    if ((gCurrentCourseId == COURSE_SHERBET_LAND) && (player->unk_0CA & UNK_0CA_LAKITU_RETRIEVAL)) {
         init_object(objectIndex, 7);
-        player->unk_0CA |= 0x10;
+        player->unk_0CA |= UNK_0CA_FRIGID_EFFECT;
     } else {
         init_object(objectIndex, 3);
     }
@@ -3144,14 +3144,14 @@ void func_80079860(s32 playerId) {
     player = &gPlayerOne[playerId];
     if ((func_80072354(objectIndex, 1) != 0) &&
         (((func_802ABDF4(player->collision.meshIndexZX) != 0) && (player->collision.surfaceDistance[2] <= 3.0f)) ||
-         (player->unk_0CA & 1) || ((player->surfaceType == OUT_OF_BOUNDS) && !(player->effects & MIDAIR_EFFECT)))) {
+         (player->unk_0CA & UNK_0CA_LAKITU_RETRIEVAL) || ((player->surfaceType == OUT_OF_BOUNDS) && !(player->effects & MIDAIR_EFFECT)))) {
         func_80090778(player);
         func_800797AC(playerId);
     }
 }
 
 void func_8007993C(s32 objectIndex, Player* player) {
-    if (player->unk_0CA & 4) {
+    if (player->unk_0CA & UNK_0CA_LAKITU_FIZZLE) {
         func_800722A4(objectIndex, 2);
         gObjectList[objectIndex].primAlpha = player->alpha;
         return;
@@ -3228,7 +3228,7 @@ void update_object_lakitu_fishing(s32 objectIndex, s32 playerId) {
             func_80073654(objectIndex);
             break;
         case 3:
-            if (!(player->unk_0CA & 2)) {
+            if (!(player->unk_0CA & UNK_0CA_HELD_BY_LAKITU)) {
                 func_80086EAC(objectIndex, 0, 3);
                 func_80073654(objectIndex);
             }
@@ -3263,7 +3263,7 @@ void update_object_lakitu_fishing2(s32 objectIndex, s32 playerId) {
         case 2: /* switch 1 */
             set_object_flag_status_true(objectIndex, 0x00000010);
             func_800736E0(objectIndex);
-            player->unk_0CA |= 0x80;
+            player->unk_0CA |= UNK_0CA_FROZEN_EFFECT;
             object_next_state(objectIndex);
             break;
         case 3: /* switch 1 */
@@ -3283,11 +3283,11 @@ void update_object_lakitu_fishing2(s32 objectIndex, s32 playerId) {
             func_80073654(objectIndex);
             break;
         case 3:
-            if ((player->surfaceType == ICE) && !(player->unk_0CA & 1) &&
+            if ((player->surfaceType == ICE) && !(player->unk_0CA & UNK_0CA_LAKITU_RETRIEVAL) &&
                 ((f64) player->collision.surfaceDistance[2] <= 30.0)) {
                 func_800722A4(objectIndex, 8);
             }
-            if (!(player->unk_0CA & 2)) {
+            if (!(player->unk_0CA & UNK_0CA_HELD_BY_LAKITU)) {
                 func_80086EAC(objectIndex, 0, 3);
                 func_80073654(objectIndex);
             }
@@ -3296,7 +3296,7 @@ void update_object_lakitu_fishing2(s32 objectIndex, s32 playerId) {
             func_8007375C(objectIndex, 0x0000001E);
             break;
         case 5:
-            player->unk_0CA &= 0xFF7F;
+            player->unk_0CA &= ~UNK_0CA_FROZEN_EFFECT;
             func_800722A4(objectIndex, 0x00000010);
             func_800722A4(objectIndex, 0x00000020);
             func_800722CC(objectIndex, 4);
@@ -3307,8 +3307,8 @@ void update_object_lakitu_fishing2(s32 objectIndex, s32 playerId) {
         case 6:
             if (func_8007375C(objectIndex, 0x000000A0) != 0) {
                 func_800722CC(objectIndex, 0x00000010);
-                player->unk_0CA &= 0xFFEF;
-                player->unk_0CA |= 0x20;
+                player->unk_0CA &= ~UNK_0CA_FRIGID_EFFECT;
+                player->unk_0CA |= UNK_0CA_THAWING_EFFECT;
             }
             break;
         case 7:
@@ -3317,7 +3317,7 @@ void update_object_lakitu_fishing2(s32 objectIndex, s32 playerId) {
         case 8:
             func_80073720(objectIndex);
             func_80072428(objectIndex);
-            player->unk_0CA &= 0xFFDF;
+            player->unk_0CA &= ~UNK_0CA_THAWING_EFFECT;
             func_800722CC(objectIndex, 1);
             func_800C9018((u8) playerId, SOUND_ARG_LOAD(0x01, 0x00, 0xFA, 0x28));
             break;


### PR DESCRIPTION
Defining many player attributes that are bit flags. These include:

* `kartProps`, various properties related to the current state of the kart  
* `kartGraphics` related to graphics that appear while driving (e.g. the POOMP! effect when landing)  
* `lakituProps` related to states when being retrieved by lakitu
* `oobProps` related to passing the Out of Bounds (OOB) plane

Less thorough documentation of `UNK_002`, which has something to do with how other players appear to you.

See `include/defines.h` for specific flag values and additional documentation. 