### PR TITLE
Instant spinout bug documentation

### DIFF
--- a/include/defines.h
+++ b/include/defines.h
@@ -331,6 +331,16 @@ enum PLACE { FIRST_PLACE, SECOND_PLACE, THIRD_PLACE, FOURTH_PLACE };
 #define MAX_TIME 0x927C0
 #define DEGREES_CONVERSION_FACTOR 182
 
+// player->unk_046
+
+/* The first time you touch a penguin or bat, and anytime you touch a thwomp during a
+   race will set a flag which will cause your next spinout to be instant (i.e. no 
+   sliding forward). Probably half-implemented code to prevent sliding through enemies,
+   but causes this bug */
+#define CRITTER_TOUCH 0x2 // Touched a penguin, bat or thwomp
+#define CRITTER_TOUCH_GATE 0x4
+#define INSTANT_SPINOUT 0x40
+
 // player->oobProps
 /* Deals with the lower out of bounds (OOB) plane on levels. Represented by fluids (water / lava)
   or nothing for Rainbow Road and Skyscraper. */

--- a/src/code_80086E70.c
+++ b/src/code_80086E70.c
@@ -1042,7 +1042,7 @@ f32 func_8008933C(Player* player, s32 objectIndex, f32 arg2, f32 arg3) {
     var_f2 = 0.0f;
     if (temp_v1->unk_18[6] == 0) {
         object = &gObjectList[objectIndex];
-        player->unk_046 |= 2;
+        player->unk_046 |= CRITTER_TOUCH;
         player->effects |= ENEMY_BONK_EFFECT;
         temp_v1->unk_18[6] = 4;
         something = (player->pos[0] - object->pos[0]) * object->velocity[0];

--- a/src/effects.c
+++ b/src/effects.c
@@ -307,7 +307,7 @@ void func_8008C8C4(Player* player, s8 playerId) {
     D_80165190[2][playerId] = 1;
     D_80165190[3][playerId] = 1;
 
-    player->unk_046 &= 0xFFBF;
+    player->unk_046 &= ~INSTANT_SPINOUT;
 
     if ((gIsPlayerTripleAButtonCombo[playerId] == true) && ((player->type & PLAYER_HUMAN) == PLAYER_HUMAN)) {
         player->currentSpeed = (f32) (player->currentSpeed + 100.0f);
@@ -325,7 +325,7 @@ void func_8008C9EC(Player* player, s8 playerIndex) {
 
     player->unk_206 = 0;
     player->slopeAccel = 0;
-    if ((player->unk_046 & 0x40) == 0x40) {
+    if ((player->unk_046 & INSTANT_SPINOUT) == INSTANT_SPINOUT) {
         player_decelerate_alternative(player, 100.0f);
     } else {
         if ((player->type & PLAYER_HUMAN) == PLAYER_HUMAN) {

--- a/src/player_controller.c
+++ b/src/player_controller.c
@@ -1582,7 +1582,7 @@ void func_8002B9CC(Player* player, s8 playerIndex, UNUSED s32 arg2) {
     s16 temp;
     s16 temp2;
 
-    if ((player->unk_046 & 2) == 2) {
+    if ((player->unk_046 & CRITTER_TOUCH) == CRITTER_TOUCH) {
         temp_f0 = D_8018CE10[playerIndex].unk_04[0];
         temp_f2 = 0;
         temp_f14 = D_8018CE10[playerIndex].unk_04[2];
@@ -1890,10 +1890,10 @@ void func_8002C7E4(Player* player, s8 playerIndex, s8 arg2) {
             if ((player->type & PLAYER_HUMAN) == PLAYER_HUMAN) {
                 func_8001CA24(player, 2.8f);
             }
-            if ((player->unk_046 & 2) == 2) {
-                if ((player->unk_046 & 4) != 4) {
-                    player->unk_046 |= 4;
-                    player->unk_046 |= 0x40;
+            if ((player->unk_046 & CRITTER_TOUCH) == CRITTER_TOUCH) {
+                if ((player->unk_046 & CRITTER_TOUCH_GATE) != CRITTER_TOUCH_GATE) {
+                    player->unk_046 |= CRITTER_TOUCH_GATE;
+                    player->unk_046 |= INSTANT_SPINOUT;
                     if (player->effects & MUSHROOM_EFFECT) {
                         remove_mushroom_effect(player);
                     }

--- a/src/update_objects.c
+++ b/src/update_objects.c
@@ -6004,7 +6004,7 @@ void func_80080B28(s32 objectIndex, s32 playerId) {
                     }
                     func_800722A4(objectIndex, 2);
                     temp_s0->unk_040 = (s16) objectIndex;
-                    temp_s0->unk_046 |= 2;
+                    temp_s0->unk_046 |= CRITTER_TOUCH;
                     temp_s0->triggers |= THWOMP_SQUISH_TRIGGER;
                     func_80088FF0(temp_s0);
                 }
@@ -6144,7 +6144,7 @@ void func_80081210(void) {
     player = gPlayerOne;
     for (var_s4 = 0; var_s4 < NUM_PLAYERS; var_s4++, player++) {
         player->tyres[FRONT_LEFT].unk_14 &= ~3;
-        player->unk_046 &= ~0x0006;
+        player->unk_046 &= ~(CRITTER_TOUCH_GATE | CRITTER_TOUCH);
         for (var_s2_3 = 0; var_s2_3 < gNumActiveThwomps; var_s2_3++) {
             objectIndex = indexObjectList1[var_s2_3];
             if (!(player->effects & BOO_EFFECT)) {


### PR DESCRIPTION
Documenting an instant spinout bug (i.e. when you spinout, you spinout in place instead of sliding as you spinout). This bug can be triggered by touching a bat, penguin or thwomp.

* Every time you touch a thwomp, it will cause your next spinout to be stationary
* The first time you touch a bat or penguin, it will cause your next spinout to be stationary. But, if you touch another bat or penguin after that, it won't effect your spinouts.
* The only way to clear this state is to spinout or leave the course. You can't clear it by falling into water/lava or getting hit.