### PR TITLE
Document and (under AVOID_UB) fix the attract timer hijacking an in-flight menu fade

### DIFF
--- a/src/menu_items.c
+++ b/src/menu_items.c
@@ -2618,7 +2618,18 @@ void func_80095574(void) {
     if (gMenuTimingCounter == 2) {
         play_sound2(SOUND_INTRO_WELCOME);
     }
+    /**
+     * @bug Pressing START in the last moments before the demo timeout plays the
+     * menu-enter chime but then drops into the demo with no music. The attract
+     * timer fires while the press-start fade is still in flight and overwrites
+     * the fade target, so the fade completes as a demo entry instead of the
+     * main menu. Roughly a 0.7 second window every attract cycle.
+     */
+#ifdef AVOID_UB
+    if ((gMenuTimingCounter > 300) && (is_screen_being_faded() == 0)) {
+#else
     if (gMenuTimingCounter > 300) {
+#endif
         func_8009E230();
         func_800CA0A0();
     }


### PR DESCRIPTION
Vanilla bug: pressing START on the splash screen in the last moments before the demo timeout plays the enter chime but then drops into the demo reel with no music. The attract timer fires while the press-start fade is still in flight and overwrites the fade target, so the fade completes as a demo entry instead of the main menu. The window is roughly 0.7 seconds every attract cycle.

This adds a @bug comment documenting it, and guards the demo arm with `is_screen_being_faded()` under `AVOID_UB` only, so the matching build is byte-identical (the non-AVOID_UB path is unchanged).

The same one-line guard was play-verified in HarbourMasters/SpaghettiKart (built from this code) using a debug rig that forces the timer to fire right after a start press: unfixed, every press gave the silent demo; fixed, every press landed in the main menu with music, and the idle demo reel still plays normally. Suggested by MegaMech in HarbourMasters/SpaghettiKart#723.