### PR TITLE
Annotate the always-true condition in func_802B4104

### DIFF
--- a/src/actors/blue_and_red_shells/update.inc.c
+++ b/src/actors/blue_and_red_shells/update.inc.c
@@ -185,6 +185,9 @@ s16 func_802B3FD0(Player* owner, struct ShellActor* shell) {
 }
 
 void func_802B4104(struct ShellActor* shell) {
+    //! @bug Both || comparisons were likely meant to be && bands around zero.
+    //! (unk48[1] < 0.25f) || (unk48[1] > -0.25f) is true for every value, so the first branch
+    //! reduces to its surfaceDistance test; the second's (unk54[1] < -0.25f) is already covered.
     if ((shell->unk30.surfaceDistance[0] < 0.0f) &&
         ((shell->unk30.unk48[1] < 0.25f) || (shell->unk30.unk48[1] > -0.25f))) {
         destroy_destructable_actor((struct Actor*) shell);


### PR DESCRIPTION
Documents one vanilla condition in `func_802B4104` (blue/red shells) that never does what it looks like it does. Both branches use `||` where an `&&` band around zero was likely intended, so the first branch's second test is true for every value and the second branch's is redundant.

Rebased down from the original three sites: the triple shell arcs and the Banshee Boardwalk lamp range are already covered on master by #778 and #779.

Comment-only change, so the preprocessed output is byte-identical and matching is unaffected.
