### PR TITLE
Two macOS build fixes: EUC-JP encoding and tool building

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -198,7 +198,11 @@ endif
 
 ifeq ($(filter clean distclean print-%,$(MAKECMDGOALS)),)
    # Make tools if out of date
-  DUMMY != make -C $(TOOLS_DIR)
+  # Not bare make: the tools makefile needs 3.82+, and macOS still ships 3.81 as
+  # `make`, which falls back to built-in rules and links the tools from only
+  # their first source file. This makefile already needs 4.0+ for !=, so
+  # $(MAKE) is always new enough.
+  DUMMY != $(MAKE) -C $(TOOLS_DIR)
   ifeq ($(DUMMY),FAIL)
     $(error Failed to build tools)
   endif

--- a/Makefile
+++ b/Makefile
@@ -636,9 +636,12 @@ $(COURSE_DISPLAYLIST_OFILES): $(BUILD_DIR)/%/course_data.o: %/course_textures.li
 #==============================================================================#
 # Source Code Generation                                                       #
 #==============================================================================#
+# Not iconv: macOS converts a backslash that follows Japanese text into the
+# fullwidth reverse solidus (0xA1C0) instead of leaving it as 0x5C, which
+# lengthens the string literals here and shifts the whole ROM.
 $(BUILD_DIR)/%.jp.c: %.c
 	$(call print,Encoding:,$<,$@)
-	$(V)iconv -t EUC-JP -f UTF-8 $< > $@
+	$(V)$(PYTHON) -c "import sys; open(sys.argv[2],'wb').write(open(sys.argv[1],encoding='utf-8').read().encode('euc_jp'))" $< $@
 
 $(BUILD_DIR)/%.o: %.c
 	$(call print,Compiling:,$<,$@)


### PR DESCRIPTION
macOS cannot currently build mk64. There are three independent causes. Two of them are here, kept as separate commits so they can be taken separately if you prefer.

The third is the truncated IDO binaries under `tools/ido-recomp/macos/`. Those were in this PR originally and have been taken out, so this no longer touches any binary. queueRAM's suggestion of building IDO from source via `ido-static-recomp` looks like the better answer there and is worth doing on its own.

---

**1. macOS iconv corrupts the EUC-JP sources, so no version can byte-match.**

macOS `iconv` converts a backslash that follows Japanese text into the fullwidth reverse solidus (`0xA1C0`) instead of leaving it as `0x5C`. GNU iconv leaves it alone, which is why this has never shown up on Linux. It bites in `src/cpu_vehicles_camera_path.c:219`:

```c
char* D_800EB710 = "ゴール直後の強制ソート\n";
```

The trailing `\n` becomes a literal two-byte character rather than an escape. 26 of the file's 199 backslashes are converted (`0x5C`: 199 -> 173, `0xA1C0`: 0 -> 26), the generated file grows by exactly 26 bytes, `.main` grows with it, and the ROM shifts:

```
First difference at ROM addr 0x1008, in entry_point
Instruction difference at ROM addr 0xec328, in build/us/src/cpu_vehicles_camera_path.jp.o
Tons of differences, must be a shifted ROM.
```

Python's `euc_jp` codec produces the bytes the cartridge actually has, and `PYTHON` is already a required build dependency. For the other two EUC-JP sources macOS iconv and Python output are byte-identical, so this only changes behaviour where iconv was wrong. Should be a no-op on Linux.

---

**2. The tools are built with bare `make`, which on macOS is 3.81.**

`tools/Makefile:51` generates its per-tool rules with `define COMPILE =`, which is 3.82 syntax. Under 3.81 those rules never take effect, so make falls back to its built-in `%: %.c` rule and links each tool from its first source file alone. `n64graphics_SOURCES := n64graphics.c utils.c`, so `utils.c` is dropped:

```
Undefined symbols for architecture arm64:
  "_g_verbosity", referenced from:
      _rgba2raw in n64graphics-7584c8.o
make[1]: *** [n64graphics] Error 1
```

Nothing there suggests the make version is at fault. `docs/basics/compiling.md` already tells macOS users to build with `gmake`, but `Makefile:201` then calls bare `make` and undoes it. The root makefile uses `!=`, which needs make 4.0, so `$(MAKE)` is always new enough.

---

**Verification.** macOS 26.6, Apple Silicon. With these two, and IDO built from source with `decompals/ido-static-recomp` instead of the checked-in binaries, `make` reports `mk64.us: OK` (`579c48e2...`), `make VERSION=eu.v10` reports `mk64.eu.v10: OK` (`a72903945...`), and `eu.v11` matches too. Before these two fixes the US ROM came out as `d2eaf74b99f3f2bc78fa5acc610fcb5e0ce39610`.
