### PR TITLE
Build the tools with $(MAKE), not bare make

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -198,7 +198,11 @@ endif
 
 ifeq ($(filter clean distclean print-%,$(MAKECMDGOALS)),)
    # Make tools if out of date
-  DUMMY != make -C $(TOOLS_DIR)
+  # Not bare make: the tools makefile needs 3.82+, and macOS still ships 3.81 as
+  # `make`, which falls back to built-in rules and links the tools from only
+  # their first source file. This makefile already needs 4.0+ for !=, so
+  # $(MAKE) is always new enough.
+  DUMMY != $(MAKE) -C $(TOOLS_DIR)
   ifeq ($(DUMMY),FAIL)
     $(error Failed to build tools)
   endif


### PR DESCRIPTION
On macOS the tools are not built, and the failure points somewhere else entirely.

`tools/Makefile:51` generates its per-tool rules with:

```make
define COMPILE =
$(1): $($1_SOURCES)
	$(CC) $(CFLAGS) $($1_CFLAGS) $$^ -o $$@
endef

$(foreach p,$(PROGRAMS),$(eval $(call COMPILE,$(p))))
```

`define NAME =` is GNU make 3.82 syntax. macOS still ships 3.81 as `make`, where those rules never take effect, so make falls back to its built-in `%: %.c` rule and links each tool from its first source file alone. `n64graphics_SOURCES := n64graphics.c utils.c`, so `utils.c` is dropped:

```
Undefined symbols for architecture arm64:
  "_g_verbosity", referenced from:
      _rgba2raw in n64graphics-7584c8.o
...
make[1]: *** [n64graphics] Error 1
```

Nothing there suggests the make version is at fault.

`docs/basics/compiling.md` already tells macOS users to build with `gmake`, but `Makefile:201` then calls bare `make` and undoes it. The root makefile uses `!=`, which needs make 4.0, so `$(MAKE)` is always new enough.

Verified on macOS 26.6, Apple Silicon. Deleting `tools/n64graphics` and running the root build: with bare `make` it stays missing and the build fails; with `$(MAKE)` it is rebuilt and make reports `mk64.us: OK`.
