### PR TITLE
Decode the tkmk00 textures instead of writing compressed bytes

### DIFF
--- a/extract_assets.py
+++ b/extract_assets.py
@@ -145,6 +145,7 @@ def main():
     for key in keys:
         assets = todo[key]
         lang, rom_offset = key
+        decoded = None
 
         if rom_offset is not None:
             magic = roms[lang][rom_offset:rom_offset + 4]
@@ -161,20 +162,26 @@ def main():
                     stdout=subprocess.PIPE,
                 ).stdout
             # TODO: binary assets in assets.json for TKMK00 until it is full understood
-            elif magic == b"TKMK" and assets[0][0].endswith(".png"):
-                (asset, pos, meta) = assets[0]
-                image = subprocess.run(
-                    [
-                        "./tools/tkmk00",
-                        "-d",
-                        "-o", str(rom_offset),
-                        "-a", meta["alpha"],
-                        "baserom." + lang + ".z64",
-                        "-",
-                    ],
-                    check=True,
-                    stdout=subprocess.PIPE,
-                ).stdout
+            elif magic == b"TKMK":
+                # A tkmk00 block is described twice at the same offset: the .tkmk00
+                # blob is the build input and wants the compressed bytes, while the
+                # .png beside it is a decoded copy. They need different bytes, so
+                # decode alongside rather than picking one for the whole group.
+                image = roms[lang][rom_offset:]
+                png = next((a for a in assets if a[0].endswith(".png")), None)
+                if png is not None:
+                    decoded = subprocess.run(
+                        [
+                            "./tools/tkmk00",
+                            "-d",
+                            "-o", str(rom_offset),
+                            "-a", png[2]["alpha"],
+                            "baserom." + lang + ".z64",
+                            "-",
+                        ],
+                        check=True,
+                        stdout=subprocess.PIPE,
+                    ).stdout
             else: # assume raw texture
                 # TODO: This grabs way more data than is necessary
                 image = roms[lang][rom_offset:]
@@ -204,7 +211,10 @@ def main():
                 elif fmt.endswith("8"): size = pixels
                 elif fmt.endswith("4"): size = math.ceil(pixels / 2)
                 elif fmt == "ia1": size = math.ceil(pixels / 8)
-            input = image[pos : pos + size]
+            # a decoded tkmk00 block is only for the .png; the blob keeps the
+            # compressed bytes the build actually assembles
+            source = decoded if (decoded is not None and asset.endswith(".png")) else image
+            input = source[pos : pos + size]
             os.makedirs(os.path.dirname(asset), exist_ok=True)
             if asset.endswith(".png"):
                 name_file = ""


### PR DESCRIPTION
The 63 PNGs extracted to `textures/*.rgba16.png` are noise. They have never been correct on a clean checkout.

Each tkmk00 block is described twice in `assets.json` at the same ROM offset - the `.tkmk00` blob under `bin/`, which is the build input, and a decoded `.png` under `textures/`:

```
"bin/background_blue_sky.rgba16.tkmk00":     {"meta":{"size":"0xCE00"}, "offsets":{"us":["0x8094C0","0x0"]}},
"textures/background_blue_sky.rgba16.png":   {"meta":{"dims":[320,240],"alpha":"0x01"}, "offsets":{"us":["0x8094C0","0x0"]}},
```

Extraction groups entries by ROM offset, then decides whether to decode by looking only at the first entry in the group:

```python
elif magic == b"TKMK" and assets[0][0].endswith(".png"):
```

The `.tkmk00` entries are listed first in `assets.json`, so `assets[0][0]` never ends in `.png`, the branch is skipped, and the PNG is written straight from the compressed bytes.

The underlying issue is that both entries share one buffer, so whichever ordering wins, the other gets the wrong bytes: the blob needs the compressed data, the png needs the decoded data. Reordering `assets.json` would just swap which one is broken.

This decodes alongside instead. The blob keeps the compressed bytes it is `.incbin`'d from, and the png gets the decoded image.

Verified on a cold extraction (`textures/`, `bin/*.tkmk00` and `.assets-local.txt` all removed first):

- before: 63 PNGs of noise. 'background_blue_sky' came out 258,704 bytes, because noise does not compress.
- after: all 63 decode, each matching the dimensions `assets.json` declares. 'background_blue_sky' is 108,512 bytes and is the title screen artwork.
- all 63 `bin/*.tkmk00` blobs still begin with `TKMK` magic and still match the cartridge byte for byte.
- `mk64.us: OK` - unchanged, as expected. Nothing in the build consumes these PNGs; `TEXTURE_DIRS` is `textures/common` and `Makefile.split` uses `textures/standalone` and `textures/raw`.

That last point is why this went unnoticed: the output is decorative until a byte-matching tkmk00 compressor exists, so nothing depended on it being right. It also only ever looked correct on an incremental run that already had the blob on disk.

Before:
<img width="320" height="240" alt="background_blue_sky-BEFORE" src="https://github.com/user-attachments/assets/bfc0945d-4cca-44f1-a9ba-4a82e4bc45a3" />

After:
<img width="320" height="240" alt="background_blue_sky-AFTER" src="https://github.com/user-attachments/assets/45c04d3a-3758-428a-bef3-51f618fe8836" />