### PR TITLE
doxygen_symbol_gen: take the map path from the version being built

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -455,7 +455,7 @@ assets:
 	$(V)$(TORCH) modding export $(BASEROM)
 
 doc:
-	$(V)$(PYTHON) $(TOOLS_DIR)/doxygen_symbol_gen.py
+	$(V)$(PYTHON) $(TOOLS_DIR)/doxygen_symbol_gen.py $(BUILD_DIR)/$(TARGET).map
 	doxygen
 	@$(PRINT) "$(GREEN)Documentation generated in docs/html$(NO_COL)\n"
 	@$(PRINT) "$(GREEN)Results can be viewed by opening docs/html/index.html in a web browser$(NO_COL)\n"
@@ -770,7 +770,7 @@ $(ROM): $(ELF)
 	$(call print,Building ROM:,$<,$@)
 	$(V)$(OBJCOPY) $(OBJCOPYFLAGS) $< $(@:.z64=.bin) -O binary
 	$(V)$(N64CKSUM) $(@:.z64=.bin) $@
-	$(V)$(PYTHON) $(TOOLS_DIR)/doxygen_symbol_gen.py
+	$(V)$(PYTHON) $(TOOLS_DIR)/doxygen_symbol_gen.py $(BUILD_DIR)/$(TARGET).map
 
 $(BUILD_DIR)/$(TARGET).hex: $(TARGET).z64
 	$(V)xxd $< > $@

--- a/tools/doxygen_symbol_gen.py
+++ b/tools/doxygen_symbol_gen.py
@@ -1,4 +1,5 @@
 # usr/bin/python3
+import sys
 
 def process_map_file(map_file_path):
     result = (
@@ -51,7 +52,10 @@ def process_map_file(map_file_path):
 
 
 if __name__ == "__main__":
-    map_file_path = "build/us/mk64.us.map"
+    # Every version's ROM rule runs this, so take the map of the version being
+    # built. Hardcoding the us one means a fresh clone that builds any other
+    # version first fails here, after its ROM is already correct.
+    map_file_path = sys.argv[1] if len(sys.argv) > 1 else "build/us/mk64.us.map"
     doxygen_formatted_content = process_map_file(map_file_path)
 
     # Specify the output file path

--- a/tools/doxygen_symbol_gen.py
+++ b/tools/doxygen_symbol_gen.py
@@ -1,4 +1,5 @@
 # usr/bin/python3
+import os
 import sys
 
 def process_map_file(map_file_path):
@@ -52,10 +53,17 @@ def process_map_file(map_file_path):
 
 
 if __name__ == "__main__":
-    # Every version's ROM rule runs this, so take the map of the version being
-    # built. Hardcoding the us one means a fresh clone that builds any other
-    # version first fails here, after its ROM is already correct.
-    map_file_path = sys.argv[1] if len(sys.argv) > 1 else "build/us/mk64.us.map"
+    # Every version's ROM rule runs this, so the caller passes the map of the
+    # version being built. Hardcoding the us one meant a fresh clone that built
+    # any other version first failed here, after its ROM was already correct.
+    if len(sys.argv) != 2:
+        sys.exit(f"usage: {sys.argv[0]} build/<version>/mk64.<version>.map")
+
+    map_file_path = sys.argv[1]
+
+    if not os.path.isfile(map_file_path):
+        sys.exit(f"{sys.argv[0]}: no map file at {map_file_path}, build that version first")
+
     doxygen_formatted_content = process_map_file(map_file_path)
 
     # Specify the output file path


### PR DESCRIPTION
Every version's ROM rule runs this script, but it hardcodes build/us/mk64.us.map. A fresh clone that builds anything other than us first fails on the last line of the recipe, after the ROM it just produced is already correct:

    make assets
    make VERSION=eu.v10
    ...
    FileNotFoundError: 'build/us/mk64.us.map'

It now takes the map path as a required argument. Both call sites in the Makefile pass build/<version>/mk64.<version>.map, and the script exits with a clear message if the argument is missing or the file is not there.

Verified on a fresh clone: us builds and matches, and eu.v10 gets past the step it used to die on.
